### PR TITLE
use raw id fields in admin for related objects #208

### DIFF
--- a/ohmg/core/admin.py
+++ b/ohmg/core/admin.py
@@ -9,9 +9,16 @@ from ohmg.core.models import (
 )
 
 
+class MapAdmin(admin.ModelAdmin):
+    search_fields = ('title',)
+    autocomplete_fields = ('locales',)
+    pass
+
+
 class DocumentAdmin(admin.ModelAdmin):
     search_fields = ("title",)
     readonly_fields = ("prepared", "title")
+    raw_id_fields = ("map", )
 
 
 class RegionAdmin(admin.ModelAdmin):
@@ -25,8 +32,9 @@ class LayerAdmin(admin.ModelAdmin):
     raw_id_fields = ("region", "layerset")
     readonly_fields = ("title",)
 
+
 admin.site.register(MapGroup)
-admin.site.register(Map)
+admin.site.register(Map, MapAdmin)
 admin.site.register(Document, DocumentAdmin)
 admin.site.register(Region, RegionAdmin)
 admin.site.register(Layer, LayerAdmin)

--- a/ohmg/georeference/admin.py
+++ b/ohmg/georeference/admin.py
@@ -25,7 +25,11 @@ class LayerSetAdmin(admin.ModelAdmin):
     search_fields = ('volume__city',)
 
 admin.site.register(LayerSet, LayerSetAdmin)
-admin.site.register(ItemBase)
+
+class ItemBaseAdmin(admin.ModelAdmin):
+    raw_id_fields = ("vrs",)
+
+admin.site.register(ItemBase, ItemBaseAdmin)
 
 class GCPAdmin(admin.ModelAdmin):
     readonly_fields = ('last_modified',)
@@ -59,11 +63,13 @@ class DocumentAdmin(admin.ModelAdmin):
     list_display = ('title', 'status', 'lock_enabled')
     exclude = ('type', 'layer_file', 'bbox_polygon')
     list_filter = ('lock_enabled', 'status')
+    raw_id_fields = ("vrs",)
 
 class LayerAdmin(admin.ModelAdmin):
     search_fields = ('title', 'status')
     exclude = ('type', 'document_file')
     list_filter = ('lock_enabled', )
+    raw_id_fields = ("vrs",)
 
 admin.site.register(Document, DocumentAdmin)
 admin.site.register(LayerV1, LayerAdmin)

--- a/ohmg/loc_insurancemaps/admin.py
+++ b/ohmg/loc_insurancemaps/admin.py
@@ -6,6 +6,7 @@ class SheetAdmin(admin.ModelAdmin):
     # search_fields = ('volume', 'sheet_no', 'doc')
     list_display = ('volume', 'sheet_no', 'doc')
     list_filter = ('volume', 'sheet_no', 'doc')
+    raw_id_fields = ('volume', 'doc')
 admin.site.register(Sheet, SheetAdmin)
 
 class VolumeAdmin(admin.ModelAdmin):
@@ -19,5 +20,6 @@ class VolumeAdmin(admin.ModelAdmin):
     search_fields = ('city', 'volume_no', 'year')
     list_display = ('identifier', 'city', 'county_equivalent', 'volume_no', 'year', 'status')
     list_filter = ('identifier', 'city', 'county_equivalent', 'volume_no', 'year', 'status')
+    autocomplete_fields = ("locales",)
 
 admin.site.register(Volume, VolumeAdmin)


### PR DESCRIPTION
small changes to close #208 . In most cases `raw_id_fields` is the best option, but for ManyToMany the autocomplete_field was better because it shows the __str__ value of the object, not just its pk.