### PR TITLE
Better preview refresh handling

### DIFF
--- a/ohmg/frontend/svelte/bundles/georeference.js
+++ b/ohmg/frontend/svelte/bundles/georeference.js
@@ -1,5 +1,5 @@
 import '@/css/interface.css';
-import Georeference from './Georeference.svelte';
+import Georeference from '@/components/Georeference.svelte';
 import '@/css/ol-overrides.css'
 
 const app = new Georeference({

--- a/ohmg/frontend/svelte/bundles/index.js
+++ b/ohmg/frontend/svelte/bundles/index.js
@@ -1,4 +1,4 @@
-import Index from './Index.svelte';
+import Index from '@/components/Index.svelte';
 
 const app = new Index({
 	target: document.getElementById("index-target"),

--- a/ohmg/frontend/svelte/bundles/map.js
+++ b/ohmg/frontend/svelte/bundles/map.js
@@ -1,7 +1,7 @@
 import '@/css/shared.css';
 import '@/css/interface.css';
 
-import Map from './Map.svelte';
+import Map from '@/components/Map.svelte';
 import '@/css/ol-overrides.css'
 
 const map = new Map({

--- a/ohmg/frontend/svelte/bundles/resource.js
+++ b/ohmg/frontend/svelte/bundles/resource.js
@@ -1,5 +1,5 @@
 import '@/css/interface.css';
-import Resource from './Resource.svelte';
+import Resource from '@/components/Resource.svelte';
 
 const app = new Resource({
 	target: document.getElementById("resource-target"),

--- a/ohmg/frontend/svelte/bundles/split.js
+++ b/ohmg/frontend/svelte/bundles/split.js
@@ -1,5 +1,5 @@
 import '@/css/interface.css';
-import Split from './Split.svelte';
+import Split from '@/components/Split.svelte';
 import '@/css/ol-overrides.css'
 
 const app = new Split({

--- a/ohmg/frontend/svelte/bundles/viewer.js
+++ b/ohmg/frontend/svelte/bundles/viewer.js
@@ -1,4 +1,4 @@
-import Viewer from './Viewer.svelte';
+import Viewer from '@/components/Viewer.svelte';
 
 const viewer = new Viewer({
 	target: document.getElementById("viewer-target"),

--- a/ohmg/frontend/svelte/rollup.config.js
+++ b/ohmg/frontend/svelte/rollup.config.js
@@ -32,7 +32,7 @@ function serve() {
 
 function componentExportDetails(componentName) {
 	return {
-    input: `src/components/${componentName.toLowerCase()}.js`,
+    input: `./bundles/${componentName.toLowerCase()}.js`,
 		output: {
 			sourcemap: true,
 			format: 'iife',

--- a/ohmg/frontend/svelte/src/base/LoadingEllipsis.svelte
+++ b/ohmg/frontend/svelte/src/base/LoadingEllipsis.svelte
@@ -1,4 +1,13 @@
-<div class='lds-ellipsis'><div></div><div></div><div></div><div></div></div>
+<script>
+    export let color = "black";
+</script>
+
+<div class='lds-ellipsis'>
+    <div style:background={color}></div>
+    <div style:background={color}></div>
+    <div style:background={color}></div>
+    <div style:background={color}></div>
+</div>
 <style>
     /* pure css loading bar */
     /* from https://loading.io/css/ */
@@ -15,7 +24,6 @@
         width: 10px;
         height: 10px;
         border-radius: 50%;
-        background: #000;
         animation-timing-function: cubic-bezier(0, 1, 1, 0);
     }
     .lds-ellipsis div:nth-child(1) {

--- a/ohmg/frontend/svelte/src/interfaces/buttons/RefreshMapButton.svelte
+++ b/ohmg/frontend/svelte/src/interfaces/buttons/RefreshMapButton.svelte
@@ -1,0 +1,27 @@
+<script>
+    import LoadingEllipsis from "@/base/LoadingEllipsis.svelte";
+
+    export let handleRefresh;
+    export let label = "click to refresh content";
+    export let delayRefresh = true;
+
+    let enableRefresh = false;
+	$: {
+		if (delayRefresh) {
+			setTimeout(() => {
+				enableRefresh = true;
+			}, 3000)
+		} else {
+			enableRefresh = true;
+		}
+	}
+</script>
+<div style="display:flex; align-items:end; z-index:10000; height:2em; margin-right:auto; margin-left:auto;">
+    <button on:click={handleRefresh} disabled={!enableRefresh} class="button" style="height:1.5em; border-radius:2px; background:#123b4f; color:white; display:flex; align-items:center; padding: 5px;">
+        {#if enableRefresh}
+        {label}
+        {:else}
+        <LoadingEllipsis color="white" />
+        {/if}
+    </button>
+</div>

--- a/ohmg/frontend/svelte/src/lib/viewers.js
+++ b/ohmg/frontend/svelte/src/lib/viewers.js
@@ -87,6 +87,14 @@ export class MapViewer {
     this.map.addInteraction(interaction)
     this.interactions[id] = interaction
   }
+  clearNonBasemapLayers() {
+    // iterate down the list of layers (by index number) and remove down to 0
+    const lyrCt = this.map.getLayers().getArray().length
+    Array.from({length: lyrCt}, (e, i)=> i).reverse().forEach((i) => {
+      // don't remove the 0 index layer as that's the basemap
+      if (i != 0 ) {this.map.getLayers().removeAt(i);}
+    })
+  }
 
   getZoom() {
     return Math.round(this.map.getView().getZoom() * 10) / 10

--- a/ohmg/frontend/svelte/src/overviews/Map.svelte
+++ b/ohmg/frontend/svelte/src/overviews/Map.svelte
@@ -188,13 +188,7 @@
 		})
 		.then(response => response.json())
 		.then(result => {
-			if (
-				MAP.item_lookup.unprepared.length != result.item_lookup.unprepared.length ||
-				MAP.item_lookup.prepared.length != result.item_lookup.prepared.length ||
-				MAP.item_lookup.georeferenced.length != result.item_lookup.georeferenced.length
-			) {
-				fetchLayerSets();
-			}
+			previewRefreshable = MAP.item_lookup.georeferenced.length != result.item_lookup.georeferenced.length
 			MAP = result;
 			processing = false
 		});
@@ -269,18 +263,18 @@
 		)
 	}
 
-	function fetchLayerSetsIfSuccess(response) {
-		if (response.success) { fetchLayerSets() } else { alert(response.message) }
-		processing = false
-	}
-	function updateLayerSets() {
+	function submitClassifiedLayers() {
 		processing = true;
 		submitPostRequest(
 			`/layerset/`,
 			CONTEXT.ohmg_post_headers,
 			"bulk-classify-layers",
 			{"map-id": MAP.identifier, "update-list": Object.entries(layersToUpdate)},
-			fetchLayerSetsIfSuccess,
+			(response) => {
+				if (!response.success) { alert(response.message) }
+				previewRefreshable = true;
+				processing = false;
+			}
 		)
 	}
 
@@ -320,6 +314,8 @@
 	let undoGeorefLayerId;
 
 	let processing = false;
+
+	let previewRefreshable = false;
 
 </script>
 
@@ -391,9 +387,7 @@
 		</div>
 		{#if sectionVis['preview']}
 		<div class="section-content" transition:slide>
-			{#key previewKey}
-				<MapPreview {CONTEXT} {LAYERSETS} />
-			{/key}
+			<MapPreview {CONTEXT} mapId={MAP.identifier} mapExtent={MAP.extent} bind:refreshable={previewRefreshable} />
 		</div>
 		{/if}
 	</section>
@@ -601,7 +595,7 @@
 						{#if classifyingLayers}
 						<button class="button is-success"
 							disabled={Object.keys(layersToUpdate).length === 0} on:click={() => {
-							updateLayerSets();
+							submitClassifiedLayers();
 							classifyingLayers = false;
 							layersToUpdate = {};
 							reinitMultimask();

--- a/ohmg/frontend/svelte/src/overviews/Map.svelte
+++ b/ohmg/frontend/svelte/src/overviews/Map.svelte
@@ -188,7 +188,9 @@
 		})
 		.then(response => response.json())
 		.then(result => {
-			previewRefreshable = MAP.item_lookup.georeferenced.length != result.item_lookup.georeferenced.length
+			if (!previewRefreshable) {
+				previewRefreshable = MAP.item_lookup.georeferenced.length != result.item_lookup.georeferenced.length
+			}
 			MAP = result;
 			processing = false
 		});


### PR DESCRIPTION
In an effort to better handle the autorefresh that currently happens on the Map overview page while processing is taking place, this PR adds a "refresh" button that will appear within the preview mosiac map whenever there is new content to load. Clicking the button fetches the layersets from the backend and updates the map interface.

This works _ok_, but the problem is that the signals and post save operations make the actual presence of a newly georeferenced layer in the system lag behind when the current flag says the map can be reloaded. Still needs work, but it at least gets closer to solving #231, with an eye toward #233.

This work is more generally to lay better foundations for an overhaul of the Map summary page, which would see the Preview section and MultiMask section much more independent of the entire page.