### PR TITLE
Iiif georef annotations

### DIFF
--- a/ohmg/core/middleware.py
+++ b/ohmg/core/middleware.py
@@ -40,3 +40,17 @@ class LoginRequiredMiddleware:
 
         else:
             return redirect_to_login(request.get_full_path())
+
+
+class CORSMiddleware(object):
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+
+        for path in settings.CORS_WHITELIST:
+            if request.path.startswith(path):
+                response["Access-Control-Allow-Origin"] = "*"
+
+        return response

--- a/ohmg/georeference/georeferencer.py
+++ b/ohmg/georeference/georeferencer.py
@@ -231,7 +231,14 @@ class Georeferencer:
             os.mkdir(directory)
         self.workspace = directory
 
-    def warp(self, src_path, output_directory=None, return_vrt=False, preview_id=None):
+    def warp(
+        self,
+        src_path,
+        output_directory=None,
+        return_vrt=False,
+        preview_id=None,
+        return_gcps_vrt=False,
+    ):
         """
         This is (now) the only entry point for creating an output warped file. By default,
         this will be a Cloud Optimized GeoTIFF (COG), via the COG driver in GDAL.
@@ -275,6 +282,9 @@ class Georeferencer:
 
         if self.verbose:
             print(gdal.Info(vrt_with_gcps_path))
+
+        if return_gcps_vrt:
+            return vrt_with_gcps_path
 
         ## if a jpg is passed in, assume that white (255, 255, 255) should be
         ## interpreted as the no data value

--- a/ohmg/iiif/urls.py
+++ b/ohmg/iiif/urls.py
@@ -1,13 +1,25 @@
 from django.urls import path
 
 from .views import (
+    IIIFSelectorView,
     IIIFResourceView,
+    IIIFGCPView,
     IIIFCanvasView,
 )
 
 urlpatterns = [
     path(
-        "iiif/resource/<str:regionid>/",
+        "iiif/selector/<str:layerid>/",
+        IIIFSelectorView.as_view(),
+        name="iiif_selector_view",
+    ),
+    path(
+        "iiif/gcps/<str:layerid>/",
+        IIIFGCPView.as_view(),
+        name="iiif_gcps_view",
+    ),
+    path(
+        "iiif/resource/<str:layerid>/",
         IIIFResourceView.as_view(),
         name="iiif_resource_view",
     ),

--- a/ohmg/iiif/urls.py
+++ b/ohmg/iiif/urls.py
@@ -24,7 +24,7 @@ urlpatterns = [
         name="iiif_resource_view",
     ),
     path(
-        "iiif/canvas/<str:mapid>/<str:layerset_category>/",
+        "iiif/mosaic/<str:mapid>/<str:layerset_category>/",
         IIIFCanvasView.as_view(),
         name="iiif_canvas_view",
     ),

--- a/ohmg/iiif/utils.py
+++ b/ohmg/iiif/utils.py
@@ -62,7 +62,7 @@ class IIIFResource:
                 ],
             )
             transposed, status = transformer.TransformPoints(False, polygon.coords[0])
-            coords_str = [f"{i[0]},{self.d_height-i[1]}" for i in transposed]
+            coords_str = [f"{i[0]},{i[1]}" for i in transposed]
 
         coords_join = " ".join(coords_str)
 

--- a/ohmg/iiif/utils.py
+++ b/ohmg/iiif/utils.py
@@ -24,7 +24,7 @@ class IIIFResource:
 
         self.d_width, self.d_height = self.document.image_size
 
-    def get_selector(self):
+    def get_selector(self, trim=False):
         ## create coordinates for the selector
         coords_str = [
             f"{int(i[0])},{self.d_height-int(i[1])}" for i in self.region.boundary.coords[0]
@@ -33,7 +33,7 @@ class IIIFResource:
         ## next step is to look for the multimask for this layer if one exists, and then
         ## transform it back to the selector coordinates.
         mm = self.layer.layerset2.multimask
-        if mm and self.layer.slug in mm:
+        if mm and self.layer.slug in mm and trim:
             wgs84 = osr.SpatialReference()
             wgs84.ImportFromEPSG(4326)
 
@@ -113,7 +113,7 @@ class IIIFResource:
             ],
         }
 
-    def get_resource(self):
+    def get_resource(self, trim=False):
         ## Ok, getting an extent or envelope from the region boundary produces cartesian x,y
         ## with 0,0 at the bottom left. However, the stored image GCP coords are with 0,0 at
         ## top left. Translating the GCP image coords is performed like this:
@@ -136,7 +136,7 @@ class IIIFResource:
             "created": self.region.created.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "modified": self.region.last_updated.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "motivation": "georeferencing",
-            "target": self.get_selector(),
+            "target": self.get_selector(trim=trim),
             "body": self.get_gcps(),
         }
 

--- a/ohmg/iiif/utils.py
+++ b/ohmg/iiif/utils.py
@@ -136,6 +136,8 @@ class IIIFResource:
             "created": self.region.created.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "modified": self.region.last_updated.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "motivation": "georeferencing",
+            ## Technically, these could be just be the urls to each resolvable endpoint,
+            ## instead of actually embedding the data here
             "target": self.get_selector(trim=trim),
             "body": self.get_gcps(),
         }

--- a/ohmg/iiif/views.py
+++ b/ohmg/iiif/views.py
@@ -18,21 +18,21 @@ class IIIFGCPView(View):
 
 class IIIFResourceView(View):
     def get(self, request, layerid):
-        return JsonResponse(IIIFResource(layerid).get_resource())
+        trim = request.GET.get("trim", "false") == "true"
+        return JsonResponse(IIIFResource(layerid).get_resource(trim=trim))
 
 
 class IIIFCanvasView(View):
     def get(self, request, mapid, layerset_category):
         ls = Map.objects.get(pk=mapid).get_layerset(layerset_category)
-        print(ls)
-        print(ls.layer_set.all())
+        trim = request.GET.get("trim", "false") == "true"
         return JsonResponse(
             {
                 "id": full_reverse("iiif_canvas_view", args=(mapid, layerset_category)),
                 "type": "AnnotationPage",
                 "@context": "http://www.w3.org/ns/anno.jsonld",
                 "items": [
-                    IIIFResource(i.pk).get_resource() for i in [k for k in ls.layer_set.all()]
+                    IIIFResource(i.pk).get_resource(trim=trim) for i in [k for k in ls.layer_set.all()]
                 ],
             }
         )

--- a/ohmg/settings.py
+++ b/ohmg/settings.py
@@ -222,6 +222,11 @@ MIDDLEWARE = (
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.middleware.security.SecurityMiddleware",
+    "ohmg.core.middleware.CORSMiddleware",
+)
+
+CORS_WHITELIST = (
+    "/iiif",
 )
 
 LOGIN_URL = "/account/login/"


### PR DESCRIPTION
This pull request adds two endpoints that return IIIF georeference annotations compatible with [Allmaps Viewer](https://viewer.allmaps.org). This work is a proof-of-concept rather than final product, and some aspects of it are likely to evolve in the future.

### endpoints

#### individual resource

`/iiif/resource/<layerid>/`

This endpoint returns an `Annotation` for a single resource, i.e. a single layer or georeferenced "region" from a document.

#### mosaic from all layers within a map

`/iiif/mosaic/<mapid>/<layerset-category>/`

This endpoint returns an `AnnotationPage` that contains all annotations for layers within a map. There is a further categorization of layers, called "Layer Sets" which groups layers of a certain type within a map. The default category is `main-content`. Other common categories for Sanborn maps are `key-map` or `graphic-map-of-volumes`, though these are not present in every map.

An extra parameter `trim=true` can be added to apply the mask trimming to each layer. This may become the default in the future...

### examples

All georeferencing shown below was performed by [helenmei](https://oldinsurancemaps.net/profile/helenmei/), [nayers](https://oldinsurancemaps.net/profile/nayers/), and [rchampine](https://oldinsurancemaps.net/profile/rchampine/) from the University of Richmond Digital Scholarship Lab.

#### example of single sheet from Mobile, Ala., 1955, vol. 1

Overview page in OldInsuranceMaps: https://oldinsurancemaps.net/layer/59798

Annotation endpoint: https://oldinsurancemaps.net/iiif/resource/59798/

In Allmaps Viewer: https://viewer.allmaps.org/?url=https%3A%2F%2Foldinsurancemaps.net%2Fiiif%2Fresource%2F59798%2F

![image](https://github.com/user-attachments/assets/99705033-9000-43ed-aabb-e9962151e510)

#### example of full mosaic of Mobile, Ala., 1955 vol. 1 (main content)

Overview page in OldInsuranceMaps: https://oldinsurancemaps.net/map/sanborn00071_009

AnnotationPage endpoint: https://oldinsurancemaps.net/iiif/mosaic/sanborn00071_009/main-content/?trim=true

In Allmaps Viewer: https://viewer.allmaps.org/?url=https%3A%2F%2Foldinsurancemaps.net%2Fiiif%2Fmosaic%2Fsanborn00071_009%2Fmain-content%2F%3Ftrim%3Dtrue

![image](https://github.com/user-attachments/assets/1fc79b35-30c3-48c1-a831-670ea7e559b6)

And here's the Key Map for the same volume: https://viewer.allmaps.org/?url=https%3A%2F%2Foldinsurancemaps.net%2Fiiif%2Fmosaic%2Fsanborn00071_009%2Fkey-map%2F%3Ftrim%3Dtrue

![image](https://github.com/user-attachments/assets/fef6fca6-dfa9-4e0d-8bfb-2183cbd8aa5c)

### notes

1. There are currently no buttons on the frontend that expose these endpoints, will add these after more testing.
2. There is a lot of old content in OldInsuranceMaps that still needs to have IIIF service links attached to it, so not every map or layer will return a valid annotation at this moment. I will wrap that work into other document management coming soon.
3. I've found at least one bug with this set up so far. With this [San Francisco volume](https://oldinsurancemaps.net/map/sanborn00813_034) in Allmaps, it looks like each region/layer is duplicated and shifted, and the adjacent region/layers are omitted. I have a feeling this may have to do with shared `ids` or something, presumably an issue in how the endpoint content is constructed. We do a ton of extra splitting in San Francisco, due to how the maps were drawn with expanded streets, though off the top of my head I'm not sure why that would matter...

    ![image](https://github.com/user-attachments/assets/cdb6898a-e16c-43e5-b24e-86e075f1ba82)

updates coming soon.


