### PR TITLE
160 preview layer

### DIFF
--- a/ohmg/core/models.py
+++ b/ohmg/core/models.py
@@ -1,11 +1,9 @@
 import os
-import glob
 import json
 import logging
 from datetime import datetime
 from pathlib import Path
 
-from osgeo import gdal
 from natsort import natsorted
 
 from django.conf import settings
@@ -27,7 +25,6 @@ from ohmg.core.utils import (
     download_image,
     copy_local_file_to_cache,
     convert_img_format,
-    random_alnum,
     get_session_user_summary,
     MONTH_CHOICES,
 )
@@ -38,7 +35,6 @@ from ohmg.core.renderers import (
     generate_document_thumbnail_content,
     generate_layer_thumbnail_content,
 )
-from ohmg.georeference.georeferencer import Georeferencer
 from ohmg.places.models import Place
 
 logger = logging.getLogger(__name__)
@@ -991,236 +987,3 @@ class LayerSet(models.Model):
             self.extent = combined.extent
 
         return super(self.__class__, self).save(*args, **kwargs)
-
-    def generate_mosaic_vrt(self):
-        """A helpful reference from the BPLv used during the creation of this method:
-        https://github.com/bplmaps/atlascope-utilities/blob/master/new-workflow/atlas-tools.py
-        """
-
-        gdal.SetConfigOption("GDAL_NUM_THREADS", "ALL_CPUS")
-        gdal.SetConfigOption("GDAL_TIFF_INTERNAL_MASK", "YES")
-
-        multimask_geojson = self.multimask_geojson
-        multimask_file_name = f"multimask-{self.category.slug}-{self.map.identifier}"
-        multimask_file = os.path.join(settings.TEMP_DIR, f"{multimask_file_name}.geojson")
-        with open(multimask_file, "w") as out:
-            json.dump(multimask_geojson, out, indent=1)
-
-        trim_list = []
-        layer_extent_polygons = []
-        for feature in multimask_geojson["features"]:
-            layer_name = feature["properties"]["layer"]
-
-            layer = Layer.objects.get(slug=layer_name)
-            if not layer.file:
-                raise Exception(f"no layer file for this layer {layer_name}")
-
-            if layer.extent:
-                extent_poly = Polygon.from_bbox(layer.extent)
-                layer_extent_polygons.append(extent_poly)
-
-            gcpgroup = layer.region.gcpgroup
-            g = Georeferencer(
-                crs=f"EPSG:{gcpgroup.crs_epsg}",
-                transformation=gcpgroup.transformation,
-                gcps_geojson=gcpgroup.as_geojson,
-            )
-            in_path = g.warp(layer.region.file.path, return_vrt=True)
-
-            trim_name = os.path.basename(in_path).replace(".vrt", "_trim.vrt")
-            out_path = os.path.join(settings.TEMP_DIR, trim_name)
-
-            wo = gdal.WarpOptions(
-                format="VRT",
-                dstSRS="EPSG:3857",
-                cutlineDSName=multimask_file,
-                cutlineLayer=multimask_file_name,
-                cutlineWhere=f"layer='{layer_name}'",
-                cropToCutline=True,
-                # srcAlpha = True,
-                # dstAlpha = True,
-                # creationOptions= [
-                #     'COMPRESS=JPEG',
-                # ]
-                # creationOptions= [
-                #     'COMPRESS=DEFLATE',
-                #     'PREDICTOR=2',
-                # ]
-            )
-            gdal.Warp(out_path, in_path, options=wo)
-            print("warped")
-
-            trim_list.append(out_path)
-
-        if len(layer_extent_polygons) > 0:
-            multi = MultiPolygon(layer_extent_polygons, srid=4326)
-
-        bounds = multi.transform(3857, True).extent
-        vo = gdal.BuildVRTOptions(
-            resolution="highest",
-            outputSRS="EPSG:3857",
-            outputBounds=bounds,
-            separate=False,
-        )
-        print("building vrt")
-
-        mosaic_vrt = os.path.join(
-            settings.TEMP_DIR, f"{self.map.identifier}-{self.category.slug}.vrt"
-        )
-        gdal.BuildVRT(mosaic_vrt, trim_list, options=vo)
-
-        return mosaic_vrt
-
-    def generate_mosaic_cog(self):
-        start = datetime.now()
-
-        mosaic_vrt = self.generate_mosaic_vrt()
-
-        print("building final geotiff")
-
-        to = gdal.TranslateOptions(
-            format="COG",
-            creationOptions=[
-                "BIGTIFF=YES",
-                "COMPRESS=JPEG",
-                "TILING_SCHEME=GoogleMapsCompatible",
-            ],
-        )
-
-        mosaic_tif = mosaic_vrt.replace(".vrt", ".tif")
-        gdal.Translate(mosaic_tif, mosaic_vrt, options=to)
-
-        existing_file_path = None
-        if self.mosaic_geotiff:
-            existing_file_path = self.mosaic_geotiff.path
-
-        file_name = f"{self.map.identifier}-{self.category.slug}__{datetime.now().strftime('%Y-%m-%d')}__{random_alnum(6)}.tif"
-
-        with open(mosaic_tif, "rb") as f:
-            self.mosaic_geotiff.save(file_name, File(f))
-
-        os.remove(mosaic_tif)
-        if existing_file_path:
-            os.remove(existing_file_path)
-
-        print(f"completed - elapsed time: {datetime.now() - start}")
-
-    def generate_mosaic_json(self, trim_all=False):
-        from cogeo_mosaic.mosaic import MosaicJSON
-        from cogeo_mosaic.backends import MosaicBackend
-
-        def write_trim_feature_cache(feature, file_path):
-            with open(file_path, "w") as f:
-                json.dump(feature, f, indent=2)
-
-        def read_trim_feature_cache(file_path):
-            with open(file_path, "r") as f:
-                feature = json.load(f)
-            return feature
-
-        logger.info(f"{self.vol.identifier} | generating mosaic json")
-
-        multimask_geojson = self.vol.multimask_geojson
-        multimask_file_name = f"multimask-{self.vol.identifier}"
-        multimask_file = os.path.join(settings.TEMP_DIR, f"{multimask_file_name}.geojson")
-        with open(multimask_file, "w") as out:
-            json.dump(multimask_geojson, out, indent=1)
-
-        logger.debug(f"{self.vol.identifier} | multimask loaded")
-        logger.info(f"{self.vol.identifier} | iterating and trimming layers")
-        trim_list = []
-        for feature in multimask_geojson["features"]:
-            layer_name = feature["properties"]["layer"]
-            layer = Layer.objects.get(slug=layer_name)
-            if not layer.file:
-                logger.error(f"{self.vol.identifier} | no layer file for this layer {layer_name}")
-                raise Exception(f"no layer file for this layer {layer_name}")
-            in_path = layer.file.path
-
-            layer_dir = os.path.dirname(in_path)
-            file_name = os.path.basename(in_path)
-            logger.debug(f"{self.vol.identifier} | processing layer file {file_name}")
-
-            file_root = os.path.splitext(file_name)[0]
-            existing_trimmed_tif = glob.glob(f"{layer_dir}/{file_root}*_trim.tif")
-            print(existing_trimmed_tif)
-
-            feat_cache_path = in_path.replace(".tif", "_trim-feature.json")
-            if os.path.isfile(feat_cache_path):
-                cached_feature = read_trim_feature_cache(feat_cache_path)
-                logger.debug(f"{self.vol.identifier} | using cached trim json boundary")
-            else:
-                cached_feature = None
-                write_trim_feature_cache(feature, feat_cache_path)
-
-            unique_id = random_alnum(6)
-            trim_vrt_path = in_path.replace(".tif", f"_{unique_id}_trim.vrt")
-            out_path = trim_vrt_path.replace(".vrt", ".tif")
-
-            # compare this multimask feature to the cached one for this layer
-            # and only (re)create a trimmed tif if they do not match
-            if feature != cached_feature or trim_all is True:
-                wo = gdal.WarpOptions(
-                    format="VRT",
-                    dstSRS="EPSG:3857",
-                    cutlineDSName=multimask_file,
-                    cutlineLayer=multimask_file_name,
-                    cutlineWhere=f"layer='{layer_name}'",
-                    cropToCutline=True,
-                    creationOptions=["COMPRESS=LZW", "BIGTIFF=YES"],
-                    resampleAlg="cubic",
-                    dstAlpha=False,
-                    dstNodata="255 255 255",
-                )
-                gdal.Warp(trim_vrt_path, in_path, options=wo)
-
-                to = gdal.TranslateOptions(
-                    format="GTiff",
-                    bandList=[1, 2, 3],
-                    creationOptions=[
-                        "TILED=YES",
-                        "COMPRESS=LZW",
-                        "PREDICTOR=2",
-                        "NUM_THREADS=ALL_CPUS",
-                        ## the following is apparently in the COG spec but doesn't work??
-                        # "COPY_SOURCE_OVERVIEWS=YES",
-                    ],
-                )
-
-                logger.debug(f"writing trimmed tif {os.path.basename(out_path)}")
-                gdal.Translate(out_path, trim_vrt_path, options=to)
-                write_trim_feature_cache(feature, feat_cache_path)
-
-                img = gdal.Open(out_path, 1)
-                if img is None:
-                    logger.warning(
-                        f"{self.vol.identifier} | file was not properly created, omitting: {file_name}"
-                    )
-                    continue
-                logger.debug(f"{self.vol.identifier} | building overview: {file_name}")
-                gdal.SetConfigOption("COMPRESS_OVERVIEW", "LZW")
-                gdal.SetConfigOption("PREDICTOR", "2")
-                gdal.SetConfigOption("GDAL_NUM_THREADS", "ALL_CPUS")
-                img.BuildOverviews("AVERAGE", [2, 4, 8, 16])
-
-            else:
-                logger.debug(f"{self.vol.identifier} | using existing trimmed tif {file_name}")
-
-            trim_list.append(out_path)
-
-        trim_urls = [
-            i.replace(os.path.dirname(settings.MEDIA_ROOT), settings.MEDIA_HOST.rstrip("/"))
-            for i in trim_list
-        ]
-        logger.info(f"{self.vol.identifier} | writing mosaic from {len(trim_urls)} trimmed tifs")
-        mosaic_data = MosaicJSON.from_urls(trim_urls, minzoom=14)
-        mosaic_json_path = os.path.join(settings.TEMP_DIR, f"{self.vol.identifier}-mosaic.json")
-        with MosaicBackend(mosaic_json_path, mosaic_def=mosaic_data) as mosaic:
-            mosaic.write(overwrite=True)
-
-        with open(mosaic_json_path, "rb") as f:
-            self.vol.mosaic_json = File(f, name=os.path.basename(mosaic_json_path))
-            self.vol.save()
-
-        logger.info(f"{self.vol.identifier} | mosaic created: {os.path.basename(mosaic_json_path)}")
-        return mosaic_json_path

--- a/ohmg/frontend/svelte/src/lib/utils.js
+++ b/ohmg/frontend/svelte/src/lib/utils.js
@@ -95,7 +95,6 @@ export function makeTitilerXYZUrl (options) {
 }
 
 export function getLayerOHMUrl(layer, host) {
-	console.log(layer)
 	const url = makeTitilerXYZUrl({
 		host: host,
 		url: layer.urls.cog,

--- a/ohmg/frontend/svelte/src/lib/utils.js
+++ b/ohmg/frontend/svelte/src/lib/utils.js
@@ -106,19 +106,8 @@ export function getLayerOHMUrl(layer, host) {
 
 export function copyToClipboard(elementId) {
 	const copyText = document.getElementById(elementId);
-	console.log(copyText)
-
-	// Select the text field
 	copyText.select();
-	console.log(0)
-	// copyText.setSelectionRange(0, 99999); // For mobile devices
-	console.log(1)
-	
-	// Copy the text inside the text field
 	navigator.clipboard.writeText(copyText.value);
-	console.log(3)
-
-	// Alert the copied text
 	alert("Copied the text: " + copyText.value);
 }
 

--- a/ohmg/frontend/svelte/src/overviews/Map.svelte
+++ b/ohmg/frontend/svelte/src/overviews/Map.svelte
@@ -692,7 +692,7 @@
 														<li><button class="is-text-link" on:click={()=>{copyToClipboard(`lyr-${layer.id}-wms-link`)}}>WMS endpoint <Copy/></button></li>
 														<li><Link href="{getLayerOHMUrl(layer, CONTEXT.titiler_host)}" external={true}>OpenHistoricalMap iD</Link></li>
 														<li><Link href="{CONTEXT.site_url}iiif/resource/{layer.id}/" external={true}>IIIF Georef Annotation (beta)</Link></li>
-														<li><Link href="https://viewer.allmaps.org/?url={encodeURIComponent(`https://oldinsurancemaps.net/iiif/resource/${layer.id}/`)}" external={true}>Allmaps Viewer (beta)</Link></li>
+														<li><Link href="https://viewer.allmaps.org/?url={encodeURIComponent(`${CONTEXT.site_url}iiif/resource/${layer.id}/`)}" external={true}>Allmaps Viewer (beta)</Link></li>
 													</ul>
 												</div>
 											  </div>

--- a/ohmg/frontend/svelte/src/overviews/sections/MapDetails.svelte
+++ b/ohmg/frontend/svelte/src/overviews/sections/MapDetails.svelte
@@ -11,8 +11,6 @@
     export let LAYERSETS = [];
     export let userFilterItems;
 
-    console.log(LAYERSETS)
-
 </script>
 
 <DownloadSectionModal id={"download-section-modal"} />
@@ -120,13 +118,13 @@
             <tr>
                 <td>IIIf Georef AnnotationPage</td>
                 <td>
-                    <Link href="https://oldinsurancemaps.net/iiif/mosaic/{MAP.identifier}/{ls.id}/?trim=true" title="View full AnnotationPage for this mosaic" external={true}>View full AnnotationPage for this mosaic (beta)</Link>
+                    <Link href="{CONTEXT.site_url}iiif/mosaic/{MAP.identifier}/{ls.id}/?trim=true" title="View full AnnotationPage for this mosaic" external={true}>View full AnnotationPage for this mosaic (beta)</Link>
                 </td>
             </tr>
             <tr>
                 <td>Allmaps</td>
                 <td>
-                    <Link href="https://viewer.allmaps.org/?url={encodeURIComponent(`https://oldinsurancemaps.net/iiif/mosaic/${MAP.identifier}/${ls.id}/?trim=true`)}" title="Open mosaic in Allmaps Viewer" external={true}>Open in Allmaps Viewer (beta)</Link>
+                    <Link href="https://viewer.allmaps.org/?url={encodeURIComponent(`${CONTEXT.site_url}iiif/mosaic/${MAP.identifier}/${ls.id}/?trim=true`)}" title="Open mosaic in Allmaps Viewer" external={true}>Open in Allmaps Viewer (beta)</Link>
                 </td>
             </tr>
         </table>

--- a/ohmg/georeference/georeferencer.py
+++ b/ohmg/georeference/georeferencer.py
@@ -263,7 +263,7 @@ class Georeferencer:
             ],
         )
         try:
-            gdal.Translate(write_out_path, src_path, options=to)
+            gdal.Translate(str(write_out_path), src_path, options=to)
         except Exception as e:
             logger.error(f"{src_path} | translate error: {str(e)}")
             raise e
@@ -318,7 +318,7 @@ class Georeferencer:
             resampleAlg="nearest",
         )
         try:
-            gdal.Warp(write_out_path, read_gcps_vrt, options=wo)
+            gdal.Warp(str(write_out_path), read_gcps_vrt, options=wo)
         except Exception as e:
             logger.error(f"{read_gcps_vrt} | warp error: {str(e)}")
             raise e
@@ -357,7 +357,7 @@ class Georeferencer:
             resampleAlg="nearest",
         )
         try:
-            gdal.Translate(write_out_path, read_modified_vrt, options=to)
+            gdal.Translate(str(write_out_path), read_modified_vrt, options=to)
         except Exception as e:
             logger.error(f"{read_modified_vrt} | translate error: {str(e)}")
             raise e

--- a/ohmg/georeference/georeferencer.py
+++ b/ohmg/georeference/georeferencer.py
@@ -3,6 +3,9 @@ import sys
 import time
 import logging
 import requests
+from pathlib import Path
+from uuid import uuid4
+
 from osgeo import gdal, osr, ogr
 
 from io import StringIO
@@ -10,6 +13,8 @@ from io import StringIO
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
+
+gdal.SetConfigOption("GDAL_NUM_THREADS", "ALL_CPUS")
 
 TRANSFORMATION_LOOKUP = {
     "tps": {
@@ -230,6 +235,136 @@ class Georeferencer:
         if not os.path.isdir(directory):
             os.mkdir(directory)
         self.workspace = directory
+
+    def make_gcps_vrt(
+        self,
+        src_path,
+        out_name: str = None,
+    ):
+        logger.debug(f"{Path(src_path).name} | create VRT with GCPs...")
+
+        if not out_name:
+            out_name = str(uuid4())
+
+        if src_path.startswith("http"):
+            src_path = f"/vsicurl/{src_path}"
+
+        out_name = f"{out_name}-gcps.vrt"
+
+        read_out_path = f"{settings.MEDIA_HOST.rstrip('/')}{settings.MEDIA_URL}vrt/{out_name}"
+        write_out_path = Path(settings.OHMG_VRT_DIR, out_name)
+
+        to = gdal.TranslateOptions(
+            GCPs=self.gcps,
+            format="VRT",
+            creationOptions=[
+                "BLOCKXSIZE=512",
+                "BLOCKYSIZE=512",
+            ],
+        )
+        try:
+            gdal.Translate(write_out_path, src_path, options=to)
+        except Exception as e:
+            logger.error(f"{src_path} | translate error: {str(e)}")
+            raise e
+
+        logger.debug(f"{Path(src_path).name} | VRT with GCPs created")
+
+        return (read_out_path, write_out_path)
+
+    def make_modified_vrt(
+        self,
+        src_path,
+        out_name: str = None,
+    ):
+        logger.debug(f"{Path(src_path).name} | create warped VRT...")
+        if not out_name:
+            out_name = str(uuid4())
+        read_gcps_vrt, write_gcps_vrt = self.make_gcps_vrt(src_path, out_name)
+
+        if read_gcps_vrt.startswith("http"):
+            read_gcps_vrt = f"/vsicurl/{read_gcps_vrt}"
+
+        out_name = f"{out_name}-modified.vrt"
+        read_out_path = f"{settings.MEDIA_HOST.rstrip('/')}{settings.MEDIA_URL}vrt/{out_name}"
+        write_out_path = Path(settings.OHMG_VRT_DIR, out_name)
+
+        wo = gdal.WarpOptions(
+            creationOptions=[
+                #     "NUM_THREADS=ALL_CPUS",
+                #     ## originally used this set of flags used
+                #     # "COMPRESS=DEFLATE",
+                #     ## should have been used PREDICTOR=2 with DEFLATE but didn't know about it
+                #     # "PREDICTOR=2"
+                #     ## useful in general but not needed when using COG driver
+                "BLOCKXSIZE=512",
+                "BLOCKYSIZE=512",
+                #     ## advisable if using JPEG with GTiff, but not supported in COG
+                #     # "JPEG_QUALITY=75",
+                #     # "PHOTOMETRIC=YCBCR",
+                #     ## Use JPEG, as recommended by Paul Ramsey article:
+                #     ## https://blog.cleverelephant.ca/2015/02/geotiff-compression-for-dummies.html
+                # "COMPRESS=JPEG",
+            ],
+            transformerOptions=[
+                f"DST_SRS={self.crs_wkt}",
+                f'MAX_GCP_ORDER={self.transformation["gdal_code"]}',
+            ],
+            format="VRT",
+            dstSRS=f"{self.crs_code}",
+            # srcNodata=src_nodata,
+            # srcAlpha=True,
+            dstAlpha=True,
+            resampleAlg="nearest",
+        )
+        try:
+            gdal.Warp(write_out_path, read_gcps_vrt, options=wo)
+        except Exception as e:
+            logger.error(f"{read_gcps_vrt} | warp error: {str(e)}")
+            raise e
+
+        logger.debug(f"{Path(src_path).name} | warped VRT created")
+
+        return (read_out_path, write_out_path)
+
+    def make_cog(
+        self,
+        src_path,
+    ):
+        a = time.time()
+        logger.debug(f"{Path(src_path).name} | create COG...")
+
+        read_modified_vrt, write_modified_vrt = self.make_modified_vrt(src_path)
+        if read_modified_vrt.startswith("http"):
+            read_modified_vrt = f"/vsicurl/{read_modified_vrt}"
+
+        write_out_path = Path(settings.TEMP_DIR, Path(src_path).stem + "-modified.tif")
+
+        to = gdal.TranslateOptions(
+            # format="GTiff",
+            format="COG",
+            # maskBand="mask",
+            creationOptions=[
+                # 'COMPRESS=DEFLATE',
+                # 'PREDICTOR=2',
+                "COMPRESS=JPEG",
+                # 'TILED=YES',
+                # 'BLOCKXSIZE=512',
+                # 'BLOCKYSIZE=512',
+                # "PHOTOMETRIC=YCBCR",
+                "TILING_SCHEME=GoogleMapsCompatible",
+            ],
+            resampleAlg="nearest",
+        )
+        try:
+            gdal.Translate(write_out_path, read_modified_vrt, options=to)
+        except Exception as e:
+            logger.error(f"{read_modified_vrt} | translate error: {str(e)}")
+            raise e
+
+        logger.info(f"{Path(src_path).name} | COG created: {round(time.time() - a, 3)} seconds.")
+
+        return write_out_path
 
     def warp(
         self,

--- a/ohmg/georeference/georeferencer.py
+++ b/ohmg/georeference/georeferencer.py
@@ -272,7 +272,7 @@ class Georeferencer:
 
         return (read_out_path, write_out_path)
 
-    def make_modified_vrt(
+    def make_warped_vrt(
         self,
         src_path,
         out_name: str = None,
@@ -334,7 +334,7 @@ class Georeferencer:
         a = time.time()
         logger.debug(f"{Path(src_path).name} | create COG...")
 
-        read_modified_vrt, write_modified_vrt = self.make_modified_vrt(src_path)
+        read_modified_vrt, write_modified_vrt = self.make_warped_vrt(src_path)
         if read_modified_vrt.startswith("http"):
             read_modified_vrt = f"/vsicurl/{read_modified_vrt}"
 

--- a/ohmg/georeference/models.py
+++ b/ohmg/georeference/models.py
@@ -653,7 +653,7 @@ class GeorefSession(SessionBase):
 
         self.update_status("warping")
         try:
-            out_path = g.warp(self.reg2.file.path)
+            out_path = g.make_cog(self.reg2.file.path)
         except Exception as e:
             logger.error(e)
             self.update_stage("finished", save=False)

--- a/ohmg/georeference/mosaicker.py
+++ b/ohmg/georeference/mosaicker.py
@@ -1,0 +1,260 @@
+import os
+import json
+import logging
+from datetime import datetime
+from glob import glob
+from pathlib import Path
+
+from osgeo import gdal
+
+from django.conf import settings
+from django.contrib.gis.geos import Polygon, MultiPolygon
+from django.core.files import File
+
+from ohmg.core.models import Layer
+from ohmg.core.utils import random_alnum
+
+from .georeferencer import Georeferencer
+
+gdal.SetConfigOption("GDAL_NUM_THREADS", "ALL_CPUS")
+gdal.SetConfigOption("GDAL_TIFF_INTERNAL_MASK", "YES")
+
+logger = logging.getLogger(__name__)
+
+
+class Mosaicker:
+    def generate_mosaic_vrt(self, layerset) -> Path:
+        """A helpful reference from the BPLv used during the creation of this method:
+        https://github.com/bplmaps/atlascope-utilities/blob/master/new-workflow/atlas-tools.py
+        """
+
+        multimask_geojson = layerset.multimask_geojson
+        multimask_file_name = f"multimask-{layerset.category.slug}-{layerset.map.identifier}"
+        multimask_file = Path(settings.TEMP_DIR, f"{multimask_file_name}.geojson")
+        with open(multimask_file, "w") as out:
+            json.dump(multimask_geojson, out, indent=1)
+
+        trim_list = []
+        layer_extent_polygons = []
+        for feature in multimask_geojson["features"]:
+            layer_name = feature["properties"]["layer"]
+
+            layer = Layer.objects.get(slug=layer_name)
+            if not layer.file:
+                raise Exception(f"no layer file for this layer {layer_name}")
+
+            if layer.extent:
+                extent_poly = Polygon.from_bbox(layer.extent)
+                layer_extent_polygons.append(extent_poly)
+
+            gcpgroup = layer.region.gcpgroup
+            g = Georeferencer(
+                crs=f"EPSG:{gcpgroup.crs_epsg}",
+                transformation=gcpgroup.transformation,
+                gcps_geojson=gcpgroup.as_geojson,
+            )
+            in_path = g.warp(layer.region.file.path, return_vrt=True)
+
+            trim_name = os.path.basename(in_path).replace(".vrt", "_trim.vrt")
+            out_path = os.path.join(settings.TEMP_DIR, trim_name)
+
+            wo = gdal.WarpOptions(
+                format="VRT",
+                dstSRS="EPSG:3857",
+                cutlineDSName=multimask_file,
+                cutlineLayer=multimask_file_name,
+                cutlineWhere=f"layer='{layer_name}'",
+                cropToCutline=True,
+                # srcAlpha = True,
+                # dstAlpha = True,
+                # creationOptions= [
+                #     'COMPRESS=JPEG',
+                # ]
+                # creationOptions= [
+                #     'COMPRESS=DEFLATE',
+                #     'PREDICTOR=2',
+                # ]
+            )
+            gdal.Warp(out_path, in_path, options=wo)
+            print("warped")
+
+            trim_list.append(out_path)
+
+        if len(layer_extent_polygons) > 0:
+            multi = MultiPolygon(layer_extent_polygons, srid=4326)
+
+        bounds = multi.transform(3857, True).extent
+        vo = gdal.BuildVRTOptions(
+            resolution="highest",
+            outputSRS="EPSG:3857",
+            outputBounds=bounds,
+            separate=False,
+        )
+        print("building vrt")
+
+        mosaic_vrt = Path(
+            settings.TEMP_DIR, f"{layerset.map.identifier}-{layerset.category.slug}.vrt"
+        )
+        gdal.BuildVRT(mosaic_vrt, trim_list, options=vo)
+
+        return mosaic_vrt
+
+    def generate_cog(self, layerset):
+        start = datetime.now()
+
+        mosaic_vrt = self.generate_mosaic_vrt(layerset)
+
+        print("building final geotiff")
+
+        to = gdal.TranslateOptions(
+            format="COG",
+            creationOptions=[
+                "BIGTIFF=YES",
+                "COMPRESS=JPEG",
+                "TILING_SCHEME=GoogleMapsCompatible",
+            ],
+        )
+        out_tif_path = mosaic_vrt.with_suffix(".tif")
+        gdal.Translate(out_tif_path, mosaic_vrt, options=to)
+
+        existing_file_path = None
+        if layerset.mosaic_geotiff:
+            existing_file_path = layerset.mosaic_geotiff.path
+
+        file_name = f"{layerset.map.identifier}-{layerset.category.slug}__{datetime.now().strftime('%Y-%m-%d')}__{random_alnum(6)}.tif"
+
+        with open(out_tif_path, "rb") as f:
+            layerset.mosaic_geotiff.save(file_name, File(f))
+
+        os.remove(out_tif_path)
+        if existing_file_path:
+            os.remove(existing_file_path)
+
+        print(f"completed - elapsed time: {datetime.now() - start}")
+
+    def generate_mosaic_json(self, layerset, trim_all=False):
+        """DEPRECATED: Currently, MosaicJSON is not used anywhere in the app."""
+        from cogeo_mosaic.mosaic import MosaicJSON
+        from cogeo_mosaic.backends import MosaicBackend
+
+        def write_trim_feature_cache(feature, file_path):
+            with open(file_path, "w") as f:
+                json.dump(feature, f, indent=2)
+
+        def read_trim_feature_cache(file_path):
+            with open(file_path, "r") as f:
+                feature = json.load(f)
+            return feature
+
+        logger.info(f"{layerset.vol.identifier} | generating mosaic json")
+
+        multimask_geojson = layerset.vol.multimask_geojson
+        multimask_file_name = f"multimask-{layerset.vol.identifier}"
+        multimask_file = os.path.join(settings.TEMP_DIR, f"{multimask_file_name}.geojson")
+        with open(multimask_file, "w") as out:
+            json.dump(multimask_geojson, out, indent=1)
+
+        logger.debug(f"{layerset.vol.identifier} | multimask loaded")
+        logger.info(f"{layerset.vol.identifier} | iterating and trimming layers")
+        trim_list = []
+        for feature in multimask_geojson["features"]:
+            layer_name = feature["properties"]["layer"]
+            layer = Layer.objects.get(slug=layer_name)
+            if not layer.file:
+                logger.error(
+                    f"{layerset.vol.identifier} | no layer file for this layer {layer_name}"
+                )
+                raise Exception(f"no layer file for this layer {layer_name}")
+            in_path = layer.file.path
+
+            layer_dir = os.path.dirname(in_path)
+            file_name = os.path.basename(in_path)
+            logger.debug(f"{layerset.vol.identifier} | processing layer file {file_name}")
+
+            file_root = os.path.splitext(file_name)[0]
+            existing_trimmed_tif = glob.glob(f"{layer_dir}/{file_root}*_trim.tif")
+            print(existing_trimmed_tif)
+
+            feat_cache_path = in_path.replace(".tif", "_trim-feature.json")
+            if os.path.isfile(feat_cache_path):
+                cached_feature = read_trim_feature_cache(feat_cache_path)
+                logger.debug(f"{layerset.vol.identifier} | using cached trim json boundary")
+            else:
+                cached_feature = None
+                write_trim_feature_cache(feature, feat_cache_path)
+
+            unique_id = random_alnum(6)
+            trim_vrt_path = in_path.replace(".tif", f"_{unique_id}_trim.vrt")
+            out_path = trim_vrt_path.replace(".vrt", ".tif")
+
+            # compare this multimask feature to the cached one for this layer
+            # and only (re)create a trimmed tif if they do not match
+            if feature != cached_feature or trim_all is True:
+                wo = gdal.WarpOptions(
+                    format="VRT",
+                    dstSRS="EPSG:3857",
+                    cutlineDSName=multimask_file,
+                    cutlineLayer=multimask_file_name,
+                    cutlineWhere=f"layer='{layer_name}'",
+                    cropToCutline=True,
+                    creationOptions=["COMPRESS=LZW", "BIGTIFF=YES"],
+                    resampleAlg="cubic",
+                    dstAlpha=False,
+                    dstNodata="255 255 255",
+                )
+                gdal.Warp(trim_vrt_path, in_path, options=wo)
+
+                to = gdal.TranslateOptions(
+                    format="GTiff",
+                    bandList=[1, 2, 3],
+                    creationOptions=[
+                        "TILED=YES",
+                        "COMPRESS=LZW",
+                        "PREDICTOR=2",
+                        "NUM_THREADS=ALL_CPUS",
+                        ## the following is apparently in the COG spec but doesn't work??
+                        # "COPY_SOURCE_OVERVIEWS=YES",
+                    ],
+                )
+
+                logger.debug(f"writing trimmed tif {os.path.basename(out_path)}")
+                gdal.Translate(out_path, trim_vrt_path, options=to)
+                write_trim_feature_cache(feature, feat_cache_path)
+
+                img = gdal.Open(out_path, 1)
+                if img is None:
+                    logger.warning(
+                        f"{layerset.vol.identifier} | file was not properly created, omitting: {file_name}"
+                    )
+                    continue
+                logger.debug(f"{layerset.vol.identifier} | building overview: {file_name}")
+                gdal.SetConfigOption("COMPRESS_OVERVIEW", "LZW")
+                gdal.SetConfigOption("PREDICTOR", "2")
+                gdal.SetConfigOption("GDAL_NUM_THREADS", "ALL_CPUS")
+                img.BuildOverviews("AVERAGE", [2, 4, 8, 16])
+
+            else:
+                logger.debug(f"{layerset.vol.identifier} | using existing trimmed tif {file_name}")
+
+            trim_list.append(out_path)
+
+        trim_urls = [
+            i.replace(os.path.dirname(settings.MEDIA_ROOT), settings.MEDIA_HOST.rstrip("/"))
+            for i in trim_list
+        ]
+        logger.info(
+            f"{layerset.vol.identifier} | writing mosaic from {len(trim_urls)} trimmed tifs"
+        )
+        mosaic_data = MosaicJSON.from_urls(trim_urls, minzoom=14)
+        mosaic_json_path = os.path.join(settings.TEMP_DIR, f"{layerset.vol.identifier}-mosaic.json")
+        with MosaicBackend(mosaic_json_path, mosaic_def=mosaic_data) as mosaic:
+            mosaic.write(overwrite=True)
+
+        with open(mosaic_json_path, "rb") as f:
+            layerset.vol.mosaic_json = File(f, name=os.path.basename(mosaic_json_path))
+            layerset.vol.save()
+
+        logger.info(
+            f"{layerset.vol.identifier} | mosaic created: {os.path.basename(mosaic_json_path)}"
+        )
+        return mosaic_json_path

--- a/ohmg/georeference/tasks.py
+++ b/ohmg/georeference/tasks.py
@@ -5,11 +5,13 @@ from pathlib import Path
 from django.conf import settings
 
 from ohmg.celeryapp import app
+from ohmg.core.models import LayerSet
 from ohmg.georeference.models import (
     PrepSession,
     GeorefSession,
     delete_expired_session_locks,
 )
+from ohmg.georeference.mosaicker import Mosaicker
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +30,7 @@ def run_georeference_session(sessionid):
     return session.pk
 
 
-@app.task
+@app.task()
 def delete_stale_sessions():
     delete_expired_session_locks()
 
@@ -37,3 +39,12 @@ def delete_stale_sessions():
 def delete_preview_vrts(id):
     for p in Path(settings.MEDIA_ROOT, "vrt").glob(f"{id}*.vrt"):
         os.remove(p)
+
+
+@app.task
+def create_mosaic_cog(layersetid):
+    try:
+        layerset = LayerSet.objects.get(pk=layersetid)
+    except LayerSet.DoesNotExist:
+        logger.warning(f"LayerSet does not exist: {layersetid}. Cancelling mosaic creation.")
+    Mosaicker().generate_cog(layerset)

--- a/ohmg/georeference/tasks.py
+++ b/ohmg/georeference/tasks.py
@@ -1,5 +1,8 @@
 import os
 import logging
+from pathlib import Path
+
+from django.conf import settings
 
 from ohmg.celeryapp import app
 from ohmg.georeference.models import (
@@ -31,14 +34,6 @@ def delete_stale_sessions():
 
 
 @app.task
-def delete_preview_vrt(base_file_path, preview_url_to_remove):
-    if not preview_url_to_remove.endswith(".vrt"):
-        logger.warning("will not delete non-VRT")
-        return
-    prev_file = os.path.basename(preview_url_to_remove)
-    prev_file_path = os.path.join(os.path.dirname(base_file_path), prev_file)
-    try:
-        if os.path.exists(prev_file_path):
-            os.remove(prev_file_path)
-    except Exception as e:
-        logger.warning(f"error while deleting preview VRT: {e}")
+def delete_preview_vrts(id):
+    for p in Path(settings.MEDIA_ROOT, "vrt").glob(f"{id}*.vrt"):
+        os.remove(p)

--- a/ohmg/georeference/views.py
+++ b/ohmg/georeference/views.py
@@ -224,7 +224,7 @@ class GeoreferenceView(View):
             file_url = settings.MEDIA_HOST.rstrip("/") + region.file.url
             try:
                 preview_id = str(uuid4())
-                read_vrt, write_vrt = g.make_modified_vrt(file_url, out_name=preview_id)
+                read_vrt, write_vrt = g.make_warped_vrt(file_url, out_name=preview_id)
 
                 return JsonResponseSuccess(
                     "all good", {"preview_url": str(read_vrt), "preview_id": preview_id}

--- a/ohmg/georeference/views.py
+++ b/ohmg/georeference/views.py
@@ -1,6 +1,5 @@
-import os
 import json
-from datetime import datetime
+from uuid import uuid4
 import logging
 
 from django.conf import settings
@@ -17,10 +16,6 @@ from ohmg.core.http import (
     generate_ohmg_context,
 )
 from ohmg.core.utils import time_this
-from ohmg.georeference.tasks import (
-    run_preparation_session,
-    run_georeference_session,
-)
 from ohmg.georeference.models import (
     SessionBase,
     PrepSession,
@@ -36,9 +31,13 @@ from ohmg.core.models import (
     Document,
     Region,
 )
+from ohmg.georeference.tasks import (
+    run_preparation_session,
+    run_georeference_session,
+    delete_preview_vrts,
+)
 from ohmg.georeference.georeferencer import Georeferencer
 from ohmg.georeference.splitter import Splitter
-from ohmg.georeference.tasks import delete_preview_vrt
 
 logger = logging.getLogger(__name__)
 
@@ -203,26 +202,10 @@ class GeoreferenceView(View):
         transformation = payload.get("transformation", "poly1")
         projection = payload.get("projection", "EPSG:3857")
         sesh_id = payload.get("sesh_id", None)
-        cleanup_preview = payload.get("cleanup_preview", None)
+        cleanup_preview_id = payload.get("last_preview_id", None)
 
-        def _generate_preview_id(request, sesh_id):
-            try:
-                ip_val = request.META.get("REMOTE_ADDR", "0.0.0.0.").replace(".", "-")
-            except Exception as e:
-                logger.warning(e)
-                ip_val = "000000000"
-
-            sesh_val = 0
-            if sesh_id:
-                sesh_val = sesh_id
-
-            return f"{ip_val}-{sesh_val}-{int(datetime.now().timestamp())}"
-
-        def _cleanup_preview(region, previous_url):
-            """Run this deletion through celery, so that it doesn't delay
-            the return of whatever function called it."""
-            if previous_url:
-                delete_preview_vrt.delay(region.file.path, previous_url)
+        if cleanup_preview_id:
+            delete_preview_vrts.delay(cleanup_preview_id)
 
         def _get_georef_session(sesh_id):
             try:
@@ -231,8 +214,6 @@ class GeoreferenceView(View):
                 sesh = None
             return sesh
 
-        # if preview mode, modify/create the vrt for this map.
-        # allow this to happen without looking for or using a session
         if operation == "preview":
             # prepare Georeferencer object
             g = Georeferencer(
@@ -240,15 +221,14 @@ class GeoreferenceView(View):
                 gcps_geojson=gcp_geojson,
                 transformation=transformation,
             )
-            preview_id = _generate_preview_id(request, sesh_id)
+            file_url = settings.MEDIA_HOST.rstrip("/") + region.file.url
             try:
-                out_path = g.warp(region.file.path, return_vrt=True, preview_id=preview_id)
-                out_path_relative = os.path.join(
-                    os.path.dirname(region.file.url), os.path.basename(out_path)
+                preview_id = str(uuid4())
+                read_vrt, write_vrt = g.make_modified_vrt(file_url, out_name=preview_id)
+
+                return JsonResponseSuccess(
+                    "all good", {"preview_url": str(read_vrt), "preview_id": preview_id}
                 )
-                preview_url = settings.MEDIA_HOST.rstrip("/") + out_path_relative
-                _cleanup_preview(region, cleanup_preview)
-                return JsonResponseSuccess("all good", {"preview_url": preview_url})
             except Exception as e:
                 logger.error(e)
                 return JsonResponseFail(str(e))
@@ -267,7 +247,6 @@ class GeoreferenceView(View):
                 logger.info(f"{sesh.__str__()} | begin run() as task")
                 run_georeference_session.apply_async((sesh.pk,))
 
-                _cleanup_preview(region, cleanup_preview)
                 return JsonResponseSuccess()
 
             else:
@@ -285,7 +264,6 @@ class GeoreferenceView(View):
 
                 sesh.delete()
 
-            _cleanup_preview(region, cleanup_preview)
             return JsonResponseSuccess()
 
         else:

--- a/ohmg/iiif/utils.py
+++ b/ohmg/iiif/utils.py
@@ -43,8 +43,10 @@ class IIIFResource:
                 transformation=self.region.gcpgroup.transformation,
                 gcps_geojson=self.region.gcpgroup.as_geojson,
             )
-            in_path = g.warp(self.region.file.path, return_gcps_vrt=True)
-            ds = gdal.Open(in_path)
+            read_path, write_path = g.make_gcps_vrt(self.region.file.path)
+            if read_path.startswith("http"):
+                read_path = f"/vsicurl/{read_path}"
+            ds = gdal.Open(read_path)
             transformer = gdal.Transformer(
                 # Source datasource
                 None,

--- a/ohmg/settings.py
+++ b/ohmg/settings.py
@@ -293,6 +293,7 @@ CELERY_TASK_ROUTES = {
     "ohmg.georeference.tasks.run_georeference_session": {"queue": "georeference"},
     "ohmg.georeference.tasks.delete_stale_sessions": {"queue": "housekeeping"},
     "ohmg.georeference.tasks.delete_preview_vrts": {"queue": "housekeeping"},
+    "ohmg.georeference.tasks.create_mosaic_cog": {"queue": "mosaic"},
     "ohmg.core.tasks.load_map_documents_as_task": {"queue": "map"},
     "ohmg.core.tasks.load_document_file_as_task": {"queue": "map"},
 }

--- a/ohmg/settings.py
+++ b/ohmg/settings.py
@@ -292,7 +292,7 @@ CELERY_TASK_ROUTES = {
     "ohmg.georeference.tasks.run_preparation_session": {"queue": "split"},
     "ohmg.georeference.tasks.run_georeference_session": {"queue": "georeference"},
     "ohmg.georeference.tasks.delete_stale_sessions": {"queue": "housekeeping"},
-    "ohmg.georeference.tasks.delete_preview_vrt": {"queue": "housekeeping"},
+    "ohmg.georeference.tasks.delete_preview_vrts": {"queue": "housekeeping"},
     "ohmg.core.tasks.load_map_documents_as_task": {"queue": "map"},
     "ohmg.core.tasks.load_document_file_as_task": {"queue": "map"},
 }

--- a/ohmg/settings.py
+++ b/ohmg/settings.py
@@ -164,6 +164,10 @@ COMPRESS_ENABLED = False
 MEDIA_URL = os.getenv("MEDIA_URL", "/uploaded/")
 MEDIA_ROOT = os.getenv("MEDIA_ROOT", BASE_DIR / "uploaded")
 
+# create directory for temp holding of publicly served VRT files
+OHMG_VRT_DIR = Path(MEDIA_ROOT, "vrt")
+OHMG_VRT_DIR.mkdir(exist_ok=True)
+
 # this is a custom setting to allow apache to be used in development
 MEDIA_HOST = os.getenv("MEDIA_HOST", SITEURL)
 


### PR DESCRIPTION
To address #160, I've just reworked and streamlined how the VRT files are created and managed on disk. The best theory I have for the issues described in that ticket are that underlying VRT files (perhaps the one with GCPs baked into it) changed between previews, such that the VSI cache would error when looking at the new one because it didn't match the old one. This is a limitation I'm familiar with in TiTiler, but perhaps it wasn't fully handled here.

The new setup puts VRT files into a new publicly accessible location.

Also reorganized the mosaic command a bit, moving it into the `georeference` app.