### PR TITLE
Consolidate and improve export options

### DIFF
--- a/ohmg/core/api/schemas.py
+++ b/ohmg/core/api/schemas.py
@@ -343,6 +343,10 @@ class LayerSchema(Schema):
     created_by: str
     last_updated_by: str
     image_url: Optional[str]
+    xyz_url: str
+    ohm_url: str
+    tilejson_url: str
+    wms_url: str
     mask: Optional[dict]
     gcps_geojson: Optional[dict]
     urls: dict
@@ -491,6 +495,9 @@ class LayerSetLayer(Schema):
     title: str
     nickname: Optional[str]
     slug: str
+    xyz_url: str
+    ohm_url: str
+    tilejson_url: str
     urls: dict
     extent: Optional[list]
 
@@ -508,12 +515,15 @@ class LayerSetSchema(Schema):
     id: str
     name: str
     map_id: str
+    xyz_url: str
+    ohm_url: str
+    tilejson_url: str
+    wms_url: str
     layers: List[LayerSetLayer]
     multimask_geojson: Optional[dict]
     extent: Optional[tuple]
     multimask_extent: Optional[tuple]
     mosaic_cog_url: Optional[str]
-    mosaic_json_url: Optional[str]
 
     @staticmethod
     def resolve_id(obj):

--- a/ohmg/core/api/schemas.py
+++ b/ohmg/core/api/schemas.py
@@ -345,8 +345,8 @@ class LayerSchema(Schema):
     image_url: Optional[str]
     xyz_url: str
     ohm_url: str
-    tilejson_url: str
     wms_url: str
+    tilejson: dict
     mask: Optional[dict]
     gcps_geojson: Optional[dict]
     urls: dict
@@ -497,7 +497,7 @@ class LayerSetLayer(Schema):
     slug: str
     xyz_url: str
     ohm_url: str
-    tilejson_url: str
+    tilejson: dict
     urls: dict
     extent: Optional[list]
 
@@ -517,7 +517,7 @@ class LayerSetSchema(Schema):
     map_id: str
     xyz_url: str
     ohm_url: str
-    tilejson_url: str
+    tilejson: dict
     wms_url: str
     layers: List[LayerSetLayer]
     multimask_geojson: Optional[dict]

--- a/ohmg/core/api/schemas.py
+++ b/ohmg/core/api/schemas.py
@@ -17,8 +17,8 @@ from ohmg.core.models import (
     Document,
     Region,
     Layer,
-    get_file_url,
 )
+from ohmg.core.utils import get_file_url
 from ohmg.georeference.models import (
     PrepSession,
     GeorefSession,

--- a/ohmg/core/api/schemas.py
+++ b/ohmg/core/api/schemas.py
@@ -24,6 +24,10 @@ from ohmg.georeference.models import (
     GeorefSession,
     SessionLock,
 )
+from ..exporters.atlascope import (
+    generate_atlascope_properties,
+    generate_atlascope_geometry,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -872,11 +876,11 @@ class AtlascopeLayersetFeature(Schema):
 
     @staticmethod
     def resolve_properties(obj):
-        return obj.as_atlascope_properties()
+        return generate_atlascope_properties(obj)
 
     @staticmethod
     def resolve_geometry(obj):
-        return obj.as_atlascope_geometry()
+        return generate_atlascope_geometry(obj)
 
 
 DocumentFullSchema.update_forward_refs()

--- a/ohmg/core/exporters/atlascope.py
+++ b/ohmg/core/exporters/atlascope.py
@@ -1,0 +1,31 @@
+import json
+
+from django.contrib.gis.geos import MultiPolygon, GEOSGeometry
+
+from ..models import LayerSet
+
+
+def generate_atlascope_properties(layerset: LayerSet):
+    return {
+        "identifier": layerset.map.identifier,
+        "publisherShort": "Sanborn",
+        "year": layerset.map.year,
+        "bibliographicEntry": "_Richards standard atlas of the town of Greenfield_ (Richards Map Company, 1918)",
+        "source": {"type": "tilejson", "url": layerset.tilejson_url},
+        "catalogPermalink": f"https://loc.gov/item/{layerset.map.identifier}",
+        "heldBy": ["Library of Congress"],
+        "sponsors": [],
+    }
+
+
+def generate_atlascope_geometry(layerset: LayerSet):
+    if layerset.multimask_geojson:
+        collection = []
+        for i in layerset.multimask_geojson["features"]:
+            geom = GEOSGeometry(json.dumps(i["geometry"]))
+            collection.append(geom)
+
+        geoms = MultiPolygon(collection)
+        return json.loads(geoms.unary_union.json)
+    else:
+        return {"type": "MultiPolygon", "coordinates": []}

--- a/ohmg/core/exporters/qlr.py
+++ b/ohmg/core/exporters/qlr.py
@@ -1,0 +1,83 @@
+import uuid
+
+import lxml.etree as et
+
+from django.conf import settings
+
+from ..models import Layer, LayerSet
+from ..utils import retrieve_srs_wkt, get_file_url
+from ..renderers import get_extent_from_file
+
+
+def generate_qlr_content(instance: Layer | LayerSet, titiler_host: str = settings.TITILER_HOST):
+    title = str(instance)
+
+    if isinstance(instance, Layer):
+        file_url = get_file_url(instance)
+        merc_extent = get_extent_from_file(instance.file, crs=3857)
+        wgs84_extent = get_extent_from_file(instance.file, crs=4326)
+    else:
+        file_url = get_file_url(instance, "mosaic_geotiff")
+        merc_extent = get_extent_from_file(instance.mosaic_geotiff, crs=3857)
+        wgs84_extent = get_extent_from_file(instance.mosaic_geotiff, crs=4326)
+
+    def make_element_with_text(tag: str, text: str, **kwargs):
+        el = et.Element(tag, **kwargs)
+        el.text = text
+        return el
+
+    id_str = f"_{str(uuid.uuid1()).replace('-', '_')}"
+
+    layername_str = title
+    datasource_str2 = (
+        "crs=EPSG:3857&dpiMode=7&format=image/png&"
+        + f"layers={file_url}&"
+        + "tilePixelRatio=0&"
+        + "styles&"
+        + f"url={titiler_host}/cog/wms/?LAYERS%3D{file_url}%26VERSION%3D1.1.1"
+    )
+
+    wkt3857_str = retrieve_srs_wkt(3857)
+
+    ## TODO: use a similar stategy here to the WKT retrieval: https://epsg.io/{code}.wkt
+    proj43857_str = "+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs"
+
+    qlr = et.Element("qlr")
+    maplayers = et.SubElement(qlr, "maplayers")
+    maplayer = et.SubElement(maplayers, "maplayer", type="raster")
+    maplayer.append(make_element_with_text("id", id_str))
+    maplayer.append(make_element_with_text("layername", layername_str))
+    maplayer.append(make_element_with_text("datasource", datasource_str2))
+    maplayer.append(make_element_with_text("provider", "wms"))
+
+    extent = et.SubElement(maplayer, "extent")
+    ymax, xmax, ymin, xmin = merc_extent
+    extent.append(make_element_with_text("xmin", str(xmin)))
+    extent.append(make_element_with_text("ymin", str(ymin)))
+    extent.append(make_element_with_text("xmax", str(xmax)))
+    extent.append(make_element_with_text("ymax", str(ymax)))
+
+    extent = et.SubElement(maplayer, "wgs84extent")
+    ymax84, xmax84, ymin84, xmin84 = wgs84_extent
+    extent.append(make_element_with_text("xmin", str(xmin84)))
+    extent.append(make_element_with_text("ymin", str(ymin84)))
+    extent.append(make_element_with_text("xmax", str(xmax84)))
+    extent.append(make_element_with_text("ymax", str(ymax84)))
+
+    srs = et.SubElement(maplayer, "srs")
+    spatailrefsys = et.SubElement(srs, "spatialrefsys", **{"nativeFormat": "Wkt"})
+    spatailrefsys.append(make_element_with_text("wkt", wkt3857_str))
+    spatailrefsys.append(make_element_with_text("proj4", proj43857_str))
+    spatailrefsys.append(make_element_with_text("srsid", "3857"))
+    spatailrefsys.append(make_element_with_text("srid", "3857"))
+    spatailrefsys.append(make_element_with_text("authid", "EPSG:3857"))
+    spatailrefsys.append(make_element_with_text("description", "WGS 84 / Pseudo-Mercator"))
+    spatailrefsys.append(make_element_with_text("projectionacronym", "merc"))
+    spatailrefsys.append(make_element_with_text("ellipsoidacronym", "EPSG:7030"))
+    spatailrefsys.append(make_element_with_text("geographicflag", "false"))
+
+    xml_str = et.tostring(
+        qlr, pretty_print=True, doctype="<!DOCTYPE qgis-layer-definition>"
+    ).decode()
+
+    return xml_str

--- a/ohmg/core/models.py
+++ b/ohmg/core/models.py
@@ -19,41 +19,24 @@ from django.db.models import Q
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 
-from ohmg.core.utils import (
+from ohmg.places.models import Place
+from .utils import (
     slugify,
     download_image,
     copy_local_file_to_cache,
     convert_img_format,
     get_session_user_summary,
     MONTH_CHOICES,
+    get_file_url,
 )
-from ohmg.core.renderers import (
+from .renderers import (
     get_image_size,
     get_extent_from_file,
     generate_document_thumbnail_content,
     generate_layer_thumbnail_content,
 )
-from ohmg.places.models import Place
 
 logger = logging.getLogger(__name__)
-
-
-def get_file_url(obj, attr_name: str = "file"):
-    f = getattr(obj, attr_name)
-    if f is None or (not f.name):
-        return ""
-
-    ## with S3 storage FileField will return an absolute url
-    if settings.ENABLE_S3_STORAGE:
-        url = f.url
-    ## this is true during local development
-    elif settings.MODE == "DEV":
-        url = f"{settings.LOCAL_MEDIA_HOST.rstrip('/')}{f.url}"
-    ## this is true in prod without S3 storage enabled
-    else:
-        url = f"{settings.SITEURL.rstrip('/')}{f.url}"
-
-    return url
 
 
 class MapGroup(models.Model):

--- a/ohmg/core/models.py
+++ b/ohmg/core/models.py
@@ -856,9 +856,20 @@ class Layer(models.Model):
         return urllib.parse.quote(self.file_url, safe="")
 
     @cached_property
-    def tilejson_url(self):
-        """Returns the TileJSON URL for this layer's geotiff"""
-        return f"{settings.TITILER_HOST}/cog/tilejson.json/?url={self.file_url_encoded}"
+    def tilejson(self):
+        """Returns the TileJSON for this layer's geotiff"""
+        attr_link = f"{settings.SITEURL}map/{self.map.pk}"
+        return {
+            "tilejson": "2.2.0",
+            "version": "1.0.0",
+            "scheme": "xyz",
+            "tiles": [self.xyz_url],
+            "minzoom": 16,
+            "maxzoom": 21,
+            "bounds": self.extent,
+            "center": [self.centroid[0], self.centroid[1], 16],
+            "attribution": f"<a href='{attr_link}'>OldInsuranceMaps.net contributors</a>",
+        }
 
     @cached_property
     def wms_url(self):
@@ -1056,9 +1067,20 @@ class LayerSet(models.Model):
         return urllib.parse.quote(self.mosaic_cog_url, safe="")
 
     @cached_property
-    def tilejson_url(self):
-        """Returns the TileJSON URL for this layerset's geotiff"""
-        return f"{settings.TITILER_HOST}/cog/tilejson.json/?url={self.file_url_encoded}"
+    def tilejson(self):
+        """Returns the TileJSON for this layer's geotiff"""
+        attr_link = f"{settings.SITEURL}map/{self.map.pk}"
+        return {
+            "tilejson": "2.2.0",
+            "version": "1.0.0",
+            "scheme": "xyz",
+            "tiles": [self.xyz_url],
+            "minzoom": 16,
+            "maxzoom": 21,
+            "bounds": self.extent,
+            "center": [self.centroid[0], self.centroid[1], 16],
+            "attribution": f"<a href='{attr_link}'>OldInsuranceMaps.net contributors</a>",
+        }
 
     @cached_property
     def wms_url(self):

--- a/ohmg/core/models.py
+++ b/ohmg/core/models.py
@@ -1044,12 +1044,6 @@ class LayerSet(models.Model):
         no COG exists, return None."""
         return get_file_url(self, "mosaic_geotiff")
 
-    @property
-    def mosaic_json_url(self):
-        """return the public url to the mosaic JSON for this annotation set. If
-        no mosaic JSON exists, return None."""
-        return get_file_url(self, "mosaic_json")
-
     @cached_property
     def file_url_encoded(self):
         """return the public url to the mosaic COG for this annotation set. If

--- a/ohmg/core/models.py
+++ b/ohmg/core/models.py
@@ -861,6 +861,11 @@ class Layer(models.Model):
         return f"{settings.TITILER_HOST}/cog/tilejson.json/?url={self.file_url_encoded}"
 
     @cached_property
+    def wms_url(self):
+        """Returns the WMS URL for this layers's geotiff"""
+        return f"{settings.TITILER_HOST}/cog/wms/?LAYERS={self.file_url_encoded}&VERSION=1.1.1"
+
+    @cached_property
     def xyz_url(self):
         """Returns a XYZ Tiles URL for this layer's geotiff"""
         xyx_base = f"{settings.TITILER_HOST}/cog/tiles/{{z}}/{{x}}/{{y}}.png?TileMatrixSetId=WebMercatorQuad"
@@ -1054,6 +1059,11 @@ class LayerSet(models.Model):
     def tilejson_url(self):
         """Returns the TileJSON URL for this layerset's geotiff"""
         return f"{settings.TITILER_HOST}/cog/tilejson.json/?url={self.file_url_encoded}"
+
+    @cached_property
+    def wms_url(self):
+        """Returns the WMS URL for this layerset's geotiff"""
+        return f"{settings.TITILER_HOST}/cog/wms/?LAYERS={self.file_url_encoded}&VERSION=1.1.1"
 
     @cached_property
     def xyz_url(self):

--- a/ohmg/core/models.py
+++ b/ohmg/core/models.py
@@ -1131,35 +1131,6 @@ class LayerSet(models.Model):
             self.multimask = None
         self.save(update_fields=["multimask"])
 
-    def as_atlascope_properties(self):
-        cog_url = self.mosaic_cog_url.replace(
-            "http://localhost:8080/uploaded/mosaics/",
-            "https://oldinsurancemaps.net/uploaded/mosaics/",
-        )
-        tilejson_url = f"{settings.TITILER_HOST}/cog/tilejson.json/?url={cog_url}"
-        return {
-            "identifier": self.map.identifier,
-            "publisherShort": "Sanborn",
-            "year": self.map.year,
-            "bibliographicEntry": "_Richards standard atlas of the town of Greenfield_ (Richards Map Company, 1918)",
-            "source": {"type": "tilejson", "url": tilejson_url},
-            "catalogPermalink": f"https://loc.gov/item/{self.map.identifier}",
-            "heldBy": ["Library of Congress"],
-            "sponsors": [],
-        }
-
-    def as_atlascope_geometry(self):
-        if self.multimask_geojson:
-            collection = []
-            for i in self.multimask_geojson["features"]:
-                geom = GEOSGeometry(json.dumps(i["geometry"]))
-                collection.append(geom)
-
-            geoms = MultiPolygon(collection)
-            return json.loads(geoms.unary_union.json)
-        else:
-            return {"type": "MultiPolygon", "coordinates": []}
-
     def save(self, *args, **kwargs):
         extents = self.layer_set.all().values_list("extent", flat=True)
         layer_extents = []

--- a/ohmg/core/renderers.py
+++ b/ohmg/core/renderers.py
@@ -16,7 +16,7 @@ gdal.UseExceptions()
 logger = logging.getLogger(__name__)
 
 
-def get_extent_from_file(file: FileField):
+def get_extent_from_file(file: FileField, crs=4326):
     """Credit: https://gis.stackexchange.com/a/201320/28414"""
 
     path = file.url if file.url.startswith("http") else file.path
@@ -27,9 +27,9 @@ def get_extent_from_file(file: FileField):
 
     src_prj = osr.SpatialReference()
     src_prj.ImportFromWkt(src.GetProjection())
-    wgs84 = osr.SpatialReference()
-    wgs84.ImportFromEPSG(4326)
-    transform = osr.CoordinateTransformation(src_prj, wgs84)
+    out_sr = osr.SpatialReference()
+    out_sr.ImportFromEPSG(crs)
+    transform = osr.CoordinateTransformation(src_prj, out_sr)
 
     ul = transform.TransformPoint(ulx, uly)
     lr = transform.TransformPoint(lrx, lry)

--- a/ohmg/core/urls.py
+++ b/ohmg/core/urls.py
@@ -16,4 +16,5 @@ urlpatterns = [
     path("region/<int:pk>", RegionView.as_view(), name="region_view"),
     path("layer/<int:pk>", LayerView.as_view(), name="layer_view"),
     path("layerset/", LayerSetView.as_view(), name="layerset_view"),
+    path("layerset/<int:pk>", LayerSetView.as_view(), name="layerset_view"),
 ]

--- a/ohmg/core/urls.py
+++ b/ohmg/core/urls.py
@@ -2,19 +2,38 @@ from django.urls import path
 
 from .views import (
     MapView,
+    LayersetDerivativeView,
     MapListView,
     DocumentView,
     RegionView,
     LayerView,
     LayerSetView,
+    ResourceDerivativeView,
 )
 
 urlpatterns = [
     path("maps/", MapListView.as_view(), name="map_list"),
     path("map/<str:identifier>", MapView.as_view(), name="map_summary"),
+    path(
+        "map/<str:mapid>/<str:category>/<str:derivative>",
+        LayersetDerivativeView.as_view(),
+        name="map_derivative",
+    ),
     path("document/<int:pk>", DocumentView.as_view(), name="document_view"),
     path("region/<int:pk>", RegionView.as_view(), name="region_view"),
+    path(
+        "region/<int:pk>/<str:derivative>",
+        ResourceDerivativeView.as_view(),
+        kwargs={"resource": "region"},
+        name="region_derivative",
+    ),
     path("layer/<int:pk>", LayerView.as_view(), name="layer_view"),
+    path(
+        "layer/<int:pk>/<str:derivative>",
+        ResourceDerivativeView.as_view(),
+        kwargs={"resource": "layer"},
+        name="layer_derivative",
+    ),
     path("layerset/", LayerSetView.as_view(), name="layerset_view"),
     path("layerset/<int:pk>", LayerSetView.as_view(), name="layerset_view"),
 ]

--- a/ohmg/core/utils.py
+++ b/ohmg/core/utils.py
@@ -228,9 +228,9 @@ def get_session_user_summary(session_list):
 
 
 def make_qlr_content(file_url, lyr_extent, title, titiler_host):
-    ## TODO: This is functional, but the extent property doesn't seem to drive the
-    ## QGIS Zoom to Layer like I was hoping. Should probably add the wgs84 extent
-    ## back in?
+    ## TODO:
+    ## - Add the wgs84 extent back in for the sake of completion
+    ## - Refactor this to a new exporters submodule I think. Atlascope and IIIF could go in there as well
 
     ## Further, it may be better to move this function to a new module, and then
     ## supply it with only a instance object and do more with that.

--- a/ohmg/core/utils.py
+++ b/ohmg/core/utils.py
@@ -6,11 +6,9 @@ import string
 import random
 import requests
 import logging
-import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Literal
-import lxml.etree as et
 
 from django.conf import settings
 from django.urls import reverse
@@ -225,70 +223,6 @@ def get_session_user_summary(session_list):
         )
         user_dict[name]["ct"] += 1
     return sorted(user_dict.values(), key=lambda item: item.get("ct"), reverse=True)
-
-
-def make_qlr_content(file_url, lyr_extent, title, titiler_host):
-    ## TODO:
-    ## - Add the wgs84 extent back in for the sake of completion
-    ## - Refactor this to a new exporters submodule I think. Atlascope and IIIF could go in there as well
-
-    ## Further, it may be better to move this function to a new module, and then
-    ## supply it with only a instance object and do more with that.
-
-    def make_element_with_text(tag: str, text: str, **kwargs):
-        el = et.Element(tag, **kwargs)
-        el.text = text
-        return el
-
-    id_str = f"_{str(uuid.uuid1()).replace('-', '_')}"
-
-    layername_str = title
-    datasource_str2 = (
-        "crs=EPSG:3857&dpiMode=7&format=image/png&"
-        + f"layers={file_url}&"
-        + "tilePixelRatio=0&"
-        + "styles&"
-        + f"url={titiler_host}/cog/wms/?LAYERS%3D{file_url}%26VERSION%3D1.1.1"
-    )
-
-    # wkt3857_str = 'PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]'
-    wkt3857_str = retrieve_srs_wkt(3857)
-
-    ## TODO: use a similar stategy here to the WKT retrieval: https://epsg.io/{code}.wkt
-    proj43857_str = "+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs"
-
-    qlr = et.Element("qlr")
-    maplayers = et.SubElement(qlr, "maplayers")
-    maplayer = et.SubElement(maplayers, "maplayer", type="raster")
-    maplayer.append(make_element_with_text("id", id_str))
-    maplayer.append(make_element_with_text("layername", layername_str))
-    maplayer.append(make_element_with_text("datasource", datasource_str2))
-    maplayer.append(make_element_with_text("provider", "wms"))
-
-    extent = et.SubElement(maplayer, "extent")
-    ymax, xmax, ymin, xmin = lyr_extent
-    extent.append(make_element_with_text("xmin", str(xmin)))
-    extent.append(make_element_with_text("ymin", str(ymin)))
-    extent.append(make_element_with_text("xmax", str(xmax)))
-    extent.append(make_element_with_text("ymax", str(ymax)))
-
-    srs = et.SubElement(maplayer, "srs")
-    spatailrefsys = et.SubElement(srs, "spatialrefsys", **{"nativeFormat": "Wkt"})
-    spatailrefsys.append(make_element_with_text("wkt", wkt3857_str))
-    spatailrefsys.append(make_element_with_text("proj4", proj43857_str))
-    spatailrefsys.append(make_element_with_text("srsid", "3857"))
-    spatailrefsys.append(make_element_with_text("srid", "3857"))
-    spatailrefsys.append(make_element_with_text("authid", "EPSG:3857"))
-    spatailrefsys.append(make_element_with_text("description", "WGS 84 / Pseudo-Mercator"))
-    spatailrefsys.append(make_element_with_text("projectionacronym", "merc"))
-    spatailrefsys.append(make_element_with_text("ellipsoidacronym", "EPSG:7030"))
-    spatailrefsys.append(make_element_with_text("geographicflag", "false"))
-
-    xml_str = et.tostring(
-        qlr, pretty_print=True, doctype="<!DOCTYPE qgis-layer-definition>"
-    ).decode()
-
-    return xml_str
 
 
 MONTH_CHOICES = [

--- a/ohmg/frontend/svelte/src/components/Map.svelte
+++ b/ohmg/frontend/svelte/src/components/Map.svelte
@@ -105,25 +105,6 @@
         layerToLayerSetLookup[lyr.slug] = ls.id;
         layerToLayerSetLookupOrig[lyr.slug] = ls.id;
       });
-
-      let mosaicUrl;
-      let ohmUrl;
-      if (ls.mosaic_cog_url) {
-        mosaicUrl = makeTitilerXYZUrl({
-          host: CONTEXT.titiler_host,
-          url: ls.mosaic_cog_url,
-        });
-        // make the OHM url here
-        const mosaicUrlEncoded = makeTitilerXYZUrl({
-          host: CONTEXT.titiler_host,
-          url: ls.mosaic_cog_url,
-          doubleEncode: true,
-        });
-        const ll = getCenter(ls.extent);
-        ohmUrl = `https://www.openhistoricalmap.org/edit#map=16/${ll[1]}/${ll[0]}&background=custom:${mosaicUrlEncoded}`;
-      }
-      ls.mosaicUrl = mosaicUrl;
-      ls.ohmUrl = ohmUrl;
     });
     LAYERSETS = newLayerSets;
     reinitMultimask();

--- a/ohmg/frontend/svelte/src/components/Map.svelte
+++ b/ohmg/frontend/svelte/src/components/Map.svelte
@@ -108,20 +108,6 @@
 
       let mosaicUrl;
       let ohmUrl;
-      if (ls.mosaic_json_url) {
-        mosaicUrl = makeTitilerXYZUrl({
-          host: CONTEXT.titiler_host,
-          url: ls.mosaic_json_url,
-        });
-        // make the OHM url here
-        const mosaicUrlEncoded = makeTitilerXYZUrl({
-          host: CONTEXT.titiler_host,
-          url: ls.mosaic_json_url,
-          doubleEncode: true,
-        });
-        const ll = getCenter(ls.extent);
-        ohmUrl = `https://www.openhistoricalmap.org/edit#map=16/${ll[1]}/${ll[0]}&background=custom:${mosaicUrlEncoded}`;
-      }
       if (ls.mosaic_cog_url) {
         mosaicUrl = makeTitilerXYZUrl({
           host: CONTEXT.titiler_host,

--- a/ohmg/frontend/svelte/src/components/cards/LayerCard.svelte
+++ b/ohmg/frontend/svelte/src/components/cards/LayerCard.svelte
@@ -10,7 +10,7 @@
 
   import BaseCard from './BaseCard.svelte';
 
-  import { copyToClipboard, getLayerOHMUrl, makeTitilerXYZUrl } from '../../lib/utils';
+  import { copyToClipboard } from '../../lib/utils';
 
   export let CONTEXT;
   export let LAYERSET_CATEGORIES;
@@ -79,11 +79,7 @@
         {/if}
         {#if downloadEnabled}
           <li>
-            <input
-              type="hidden"
-              id="lyr-{layer.id}-xyz-link"
-              value={`${makeTitilerXYZUrl({ host: CONTEXT.titiler_host, url: layer.urls.cog })}`}
-            />
+            <input type="hidden" id="lyr-{layer.id}-xyz-link" value={layer.xyz_url} />
             <input
               type="hidden"
               id="lyr-{layer.id}-wms-link"
@@ -128,9 +124,7 @@
                         >
                       </li>
                       <li>
-                        <Link href={getLayerOHMUrl(layer, CONTEXT.titiler_host)} external={true}
-                          >OpenHistoricalMap iD</Link
-                        >
+                        <Link href={layer.ohm_url} external={true}>OpenHistoricalMap iD</Link>
                       </li>
                       <li>
                         <Link href="{CONTEXT.site_url}iiif/resource/{layer.id}/" external={true}

--- a/ohmg/frontend/svelte/src/components/common/MapboxLogoLink.svelte
+++ b/ohmg/frontend/svelte/src/components/common/MapboxLogoLink.svelte
@@ -17,6 +17,7 @@
     position: relative;
     display: block;
     height: 20px;
+    width: 20px;
     margin-top: -30px;
     margin-left: 10px;
     z-index: 1000;

--- a/ohmg/frontend/svelte/src/components/interfaces/MultiMask.svelte
+++ b/ohmg/frontend/svelte/src/components/interfaces/MultiMask.svelte
@@ -30,7 +30,7 @@
   import ToolUIButton from '../buttons/ToolUIButton.svelte';
   import ExpandElement from '../buttons/ExpandElement.svelte';
 
-  import { makeTitilerXYZUrl, usaExtent } from '../../lib/utils';
+  import { usaExtent } from '../../lib/utils';
   import { submitPostRequest } from '../../lib/requests';
   import { MapViewer } from '../../lib/viewers';
   import { LyrMousePosition } from '../../lib/controls';
@@ -85,12 +85,10 @@
     layerLookup = {};
     trimShapeSource.clear();
     LAYERSET.layers.forEach(function (layerDef) {
+      console.log(layerDef);
       let newLayer = new TileLayer({
         source: new XYZ({
-          url: makeTitilerXYZUrl({
-            host: CONTEXT.titiler_host,
-            url: layerDef.urls.cog,
-          }),
+          url: layerDef.xyz_url,
         }),
         extent: transformExtent(layerDef.extent, 'EPSG:4326', 'EPSG:3857'),
       });

--- a/ohmg/frontend/svelte/src/components/overviews/sections/MapDetails.svelte
+++ b/ohmg/frontend/svelte/src/components/overviews/sections/MapDetails.svelte
@@ -90,12 +90,12 @@
       <h4>{ls.name} ({ls.layers.length} layer{ls.layers.length > 1 ? 's' : ''})</h4>
       <table>
         <tbody>
-          {#if ls.mosaicUrl}
+          {#if ls.xyz_url}
             <tr>
               <td>XYZ Tiles URL</td>
               <td>
-                {#if ls.mosaicUrl}
-                  <pre style="margin:0;">{ls.mosaicUrl}</pre>
+                {#if ls.xyz_url}
+                  <pre style="margin:0;">{ls.xyz_url}</pre>
                 {:else}
                   n/a
                 {/if}
@@ -104,8 +104,8 @@
             <tr>
               <td>OpenHistoricalMap</td>
               <td>
-                {#if ls.ohmUrl}
-                  <Link href={ls.ohmUrl} title="Open mosaic in OHM Editor" external={true}
+                {#if ls.ohm_url}
+                  <Link href={ls.ohm_url} title="Open mosaic in OHM Editor" external={true}
                     >Open in OpenHistoricalMap iD editor</Link
                   >
                 {:else}

--- a/ohmg/frontend/svelte/src/lib/utils.js
+++ b/ohmg/frontend/svelte/src/lib/utils.js
@@ -3,6 +3,7 @@ import ImageStatic from 'ol/source/ImageStatic';
 import OSM from 'ol/source/OSM';
 import XYZ from 'ol/source/XYZ';
 import TileWMS from 'ol/source/TileWMS';
+import TileJSON from 'ol/source/TileJSON';
 
 import GeoJSON from 'ol/format/GeoJSON';
 
@@ -154,15 +155,13 @@ export function makeLayerGroupFromLayerSet(options) {
     return lyrGroup;
   }
   options.layerSet.layers.forEach(function (layer) {
-    if (layer.slug != options.excludeLayerId && layer.extent) {
-      const lyrExtent = transformExtent(layer.extent, 'EPSG:4326', 'EPSG:3857');
-
+    if (layer.slug != options.excludeLayerId) {
       // create the actual ol layers and add to group.
       let newLayer = new TileLayer({
-        source: new XYZ({
-          url: layer.xyz_url,
+        source: new TileJSON({
+          tileJSON: layer.tilejson,
         }),
-        extent: lyrExtent,
+        extent: transformExtent(layer.tilejson.bounds, 'EPSG:4326', 'EPSG:3857'),
       });
 
       lyrGroup.getLayers().push(newLayer);

--- a/ohmg/frontend/svelte/src/lib/utils.js
+++ b/ohmg/frontend/svelte/src/lib/utils.js
@@ -97,16 +97,6 @@ export function makeTitilerXYZUrl(options) {
   return finalUrl;
 }
 
-export function getLayerOHMUrl(layer, host) {
-  const url = makeTitilerXYZUrl({
-    host: host,
-    url: layer.urls.cog,
-    doubleEncode: true,
-  });
-  const ll = getCenter(layer.extent);
-  return `https://www.openhistoricalmap.org/edit#map=16/${ll[1]}/${ll[0]}&background=custom:${url}`;
-}
-
 export function copyToClipboard(elementId) {
   const copyText = document.getElementById(elementId);
   copyText.select();
@@ -170,10 +160,7 @@ export function makeLayerGroupFromLayerSet(options) {
       // create the actual ol layers and add to group.
       let newLayer = new TileLayer({
         source: new XYZ({
-          url: makeTitilerXYZUrl({
-            host: options.titilerHost,
-            url: layer.urls.cog,
-          }),
+          url: layer.xyz_url,
         }),
         extent: lyrExtent,
       });

--- a/ohmg/georeference/georeferencer.py
+++ b/ohmg/georeference/georeferencer.py
@@ -2,7 +2,6 @@ import os
 import sys
 import time
 import logging
-import requests
 from pathlib import Path
 from uuid import uuid4
 
@@ -11,6 +10,8 @@ from osgeo import gdal, osr, ogr
 from io import StringIO
 
 from django.conf import settings
+
+from ohmg.core.utils import retrieve_srs_wkt
 
 logger = logging.getLogger(__name__)
 
@@ -95,24 +96,6 @@ def anticipate_polynomial_order(gcp_count):
         ## based on recs from GDAL docs, use poly2 here even
         ## though there are enough GCPs for poly3
         return "poly3"
-
-
-def retrieve_srs_wkt(code):
-    srs_cache_dir = os.path.join(settings.CACHE_DIR, "srs_wkt")
-    if not os.path.isdir(srs_cache_dir):
-        os.makedirs(srs_cache_dir, exist_ok=True)
-    cache_path = os.path.join(srs_cache_dir, f"{code}-wkt.txt")
-    if os.path.isfile(cache_path):
-        with open(cache_path, "r") as o:
-            wkt = o.read()
-    else:
-        url = f"https://epsg.io/{code}.wkt"
-        response = requests.get(url)
-        wkt = response.content.decode("utf-8")
-        with open(cache_path, "w") as o:
-            o.write(wkt)
-
-    return wkt
 
 
 class VRTHandler:

--- a/ohmg/georeference/mosaicker.py
+++ b/ohmg/georeference/mosaicker.py
@@ -13,8 +13,8 @@ from django.contrib.gis.geos import Polygon, MultiPolygon
 from django.core.files import File
 from django.core.files.storage import get_storage_class
 
-from ohmg.core.models import Layer, LayerSet, get_file_url
-from ohmg.core.utils import random_alnum
+from ohmg.core.models import Layer, LayerSet
+from ohmg.core.utils import random_alnum, get_file_url
 
 from .georeferencer import Georeferencer, VRTHandler
 

--- a/ohmg/georeference/views.py
+++ b/ohmg/georeference/views.py
@@ -14,7 +14,7 @@ from ohmg.core.http import (
     validate_post_request,
     generate_ohmg_context,
 )
-from ohmg.core.utils import time_this
+from ohmg.core.utils import time_this, get_file_url
 from ohmg.georeference.models import (
     SessionBase,
     PrepSession,
@@ -29,7 +29,6 @@ from ohmg.core.api.schemas import (
 from ohmg.core.models import (
     Document,
     Region,
-    get_file_url,
 )
 from ohmg.georeference.tasks import (
     run_preparation_session,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "beautifulsoup4",
     "python-slugify",
     "humanize",
+    "lxml",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR introduces a new paradigm for how users can get downloads and access to web services. It started with the idea of adding QLR exports so that a layer or mosaic could be opened directly in QGIS. It expanded to a better pattern overall with more intuitive urls. These are mimicked for both "regions" and "layers" so that the same resources are easy to get from each page.

1. available for all regions or layers
  - `/region|layer/<id>/img` redirects to download the ungeoreferenced image for this resource
2. available for all regions that have been georeferenced and layers
  - `/region|layer/<id>/cog` redirects to download a cog
  - `/region|layer/<id>/tilejson` returns a tilejson JSON for this resource
  - `/region|layer/<id>/qlr` returns a QLR file (XML) that embeds the WMS url for a layer
  - `/region|layer/<id>/ohm` redirects to OpenHistoricalMap iD editor with this layer as custom basemap
  - `/region|layer/<id>/services` returns a JSON response with the different service urls, `xyx`, `wms`, and `tilejson` (same as above url)
3. available for all layersets that have a mosaic cog generated
  - `/map/<mapid>/<layerset-category>/<deritvative>` same as all endpoints described in 2 above

Through this work I also added properties directly to the region that calculate the various urls used to run the endpoints above. In some cases I replaced frontend calculated URLs with these, though there is more to do on that front.