### PR TITLE
293 no split operation

### DIFF
--- a/ohmg/frontend/svelte/src/components/Splitter.svelte
+++ b/ohmg/frontend/svelte/src/components/Splitter.svelte
@@ -412,6 +412,7 @@
 <ConfirmNoSplitModal
   documentId={DOCUMENT.id}
   {CONTEXT}
+  {sessionId}
   callback={() => {
     leaveOkay = true;
     window.location.href = `/map/${DOCUMENT.map}`;

--- a/ohmg/frontend/svelte/src/components/modals/ConfirmNoSplitModal.svelte
+++ b/ohmg/frontend/svelte/src/components/modals/ConfirmNoSplitModal.svelte
@@ -4,12 +4,21 @@
 
   export let CONTEXT;
   export let documentId;
+  export let sessionId = null;
   export let processing;
   export let callback = null;
 
   function postNoSplit() {
     processing = true;
-    submitPostRequest(`/split/${documentId}/`, CONTEXT.ohmg_post_headers, 'no-split', {}, callback);
+    submitPostRequest(
+      `/split/${documentId}/`,
+      CONTEXT.ohmg_post_headers,
+      'no-split',
+      {
+        sessionId: sessionId,
+      },
+      callback,
+    );
   }
 </script>
 

--- a/ohmg/georeference/tasks.py
+++ b/ohmg/georeference/tasks.py
@@ -24,6 +24,14 @@ def run_preparation_session(sessionid):
 
 
 @app.task
+def bulk_run_preparation_sessions(sessionids):
+    for sessionid in sessionids:
+        session = PrepSession.objects.get(pk=sessionid)
+        session.run()
+    return sessionids
+
+
+@app.task
 def run_georeference_session(sessionid):
     session = GeorefSession.objects.get(pk=sessionid)
     session.run()

--- a/ohmg/georeference/views.py
+++ b/ohmg/georeference/views.py
@@ -129,8 +129,9 @@ class SplitView(View):
             sesh.data["split_needed"] = False
             sesh.save(update_fields=["data"])
 
-            new_region = sesh.run()[0]
-            return JsonResponseSuccess(f"no split, new region created: {new_region.pk}")
+            logger.info(f"{sesh.__str__()} | begin run() as task")
+            run_preparation_session.apply_async((sesh.pk,))
+            return JsonResponseSuccess()
 
         elif operation == "bulk-no-split":
             sessionids = []

--- a/ohmg/georeference/views.py
+++ b/ohmg/georeference/views.py
@@ -114,6 +114,11 @@ class SplitView(View):
             # sesh could be None if this post has been made directly from an overview page,
             # not from the split interface where a session will have already been made.
             if sesh is None:
+                if PrepSession.objects.filter(doc2=document).exists():
+                    msg = f"one or more PrepSessions already exist for Document {document.pk}"
+                    logger.warning(msg)
+                    return JsonResponseFail(msg)
+
                 sesh = PrepSession.objects.create(
                     doc2=document,
                     user=request.user,

--- a/ohmg/settings.py
+++ b/ohmg/settings.py
@@ -317,6 +317,7 @@ CELERY_TASK_QUEUES = (
 
 CELERY_TASK_ROUTES = {
     "ohmg.georeference.tasks.run_preparation_session": {"queue": "split"},
+    "ohmg.georeference.tasks.bulk_run_preparation_sessions": {"queue": "split"},
     "ohmg.georeference.tasks.run_georeference_session": {"queue": "georeference"},
     "ohmg.georeference.tasks.delete_stale_sessions": {"queue": "housekeeping"},
     "ohmg.georeference.tasks.delete_preview_vrts": {"queue": "housekeeping"},


### PR DESCRIPTION
This PR should fix the underlying issues that were causing both #293 and #295.

- Send the "no split" operation to celery as an async task, which is the same way that the split or georeferencing operations have always been submitted. Synchronous handling of "no split" did work well originally, but since implementing an S3 storage backend, that process now takes a bit longer to complete. The real problem was that while someone was waiting for the synchronous response, there was nothing stopping someone else clicking the button, or even the same person clicking it multiple times. Now, using the same submission structure that "split" and "georeference" operations use, extra clicks will get an immediate error return, and the items are properly locked. This will fix #295.
- For the stuck processing items in #293, I'm hopeful that the above fix will also address the problem. However, I also found that if someone had entered the splitting interface and then clicked "no split needed" from there, the confirmation modal was not actually pushing the sessionId through to the POST request, meaning that in those cases, a new session was created and submitted directly within the view.

The main thing to do now is clean up all of the orphan content within the database and then watch for these issues in the future.