### PR TITLE
set archive file name without digits in front

### DIFF
--- a/ohmg/conf/management/commands/run-db-backup.py
+++ b/ohmg/conf/management/commands/run-db-backup.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
     Daily backups are stored locally and rotated everyday. Directory structure:
     LOCAL
       .db_backups/daily/
-        <YYYYMMDD>__<db name>.sql
+        <db name>__<YYYYMMDD>.sql
         (repeated for the last 10 days)
 
     S3
@@ -70,7 +70,7 @@ class Command(BaseCommand):
         db_pass = settings.DATABASES["default"]["PASSWORD"]
         db_port = settings.DATABASES["default"]["PORT"]
 
-        fname = now.strftime(f"%Y%m%d__{db_name}.sql")
+        fname = now.strftime(f"{db_name}__%Y%m%d.sql")
         fpath = Path(backup_dir, fname)
 
         cmd = [


### PR DESCRIPTION
A small change to the daily backup script so that the files it makes can be more easily turned into restored snapshot dbs.