### PR TITLE
reorg s3 utils

### DIFF
--- a/ohmg/core/utils/__init__.py
+++ b/ohmg/core/utils/__init__.py
@@ -39,13 +39,17 @@ def random_alnum(size=6):
 def get_boto3_s3_client():
     import boto3
 
-    return boto3.client(
-        "s3",
-        region_name=settings.AWS_S3_REGION_NAME,
-        aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-        endpoint_url=settings.AWS_S3_ENDPOINT_URL,
-    )
+    if settings.AWS_ACCESS_KEY_ID:
+
+        return boto3.client(
+            "s3",
+            region_name=settings.AWS_S3_REGION_NAME,
+            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+            endpoint_url=settings.AWS_S3_ENDPOINT_URL,
+        )
+    else:
+        return None
 
 
 MONTH_CHOICES = [

--- a/ohmg/core/utils/__init__.py
+++ b/ohmg/core/utils/__init__.py
@@ -36,22 +36,6 @@ def random_alnum(size=6):
     return code
 
 
-def get_boto3_s3_client():
-    import boto3
-
-    if settings.AWS_ACCESS_KEY_ID:
-
-        return boto3.client(
-            "s3",
-            region_name=settings.AWS_S3_REGION_NAME,
-            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-            endpoint_url=settings.AWS_S3_ENDPOINT_URL,
-        )
-    else:
-        return None
-
-
 MONTH_CHOICES = [
     (1, "JAN."),
     (2, "FEB."),

--- a/ohmg/core/utils/s3.py
+++ b/ohmg/core/utils/s3.py
@@ -1,0 +1,14 @@
+def get_boto3_s3_client():
+    import boto3
+
+    if settings.AWS_ACCESS_KEY_ID:
+
+        return boto3.client(
+            "s3",
+            region_name=settings.AWS_S3_REGION_NAME,
+            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+            endpoint_url=settings.AWS_S3_ENDPOINT_URL,
+        )
+    else:
+        return None

--- a/ohmg/georeference/tasks.py
+++ b/ohmg/georeference/tasks.py
@@ -7,7 +7,7 @@ from django.conf import settings
 
 from ohmg.conf.celery import app
 from ohmg.core.models import LayerSet
-from ohmg.core.utils import get_boto3_s3_client
+from ohmg.core.utils.s3 import get_boto3_s3_client
 
 from .models import (
     GeorefSession,

--- a/ohmg/georeference/utils.py
+++ b/ohmg/georeference/utils.py
@@ -10,7 +10,7 @@ import morecantile
 from django.conf import settings
 from rio_tiler.io import Reader
 
-from ohmg.core.utils import get_boto3_s3_client
+from ohmg.core.utils.s3 import get_boto3_s3_client
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/restart_services.sh
+++ b/scripts/restart_services.sh
@@ -1,0 +1,8 @@
+#! /usr/bin/bash
+
+echo "restart celery_main"
+sudo systemctl restart celery_main
+echo "restart celery_mosaic"
+sudo systemctl restart celery_main
+echo "restart uwsgi"
+sudo systemctl restart celery_main


### PR DESCRIPTION
Fixes a bug where a lack of valid s3 creds in the settings raised an error, even if object storage isn't in use.

Also add a small bash script to restart all services, now that there are two different celery workers running.